### PR TITLE
[Shop] 상점 Scheduling 적용

### DIFF
--- a/alarm-service/Dockerfile
+++ b/alarm-service/Dockerfile
@@ -1,0 +1,11 @@
+# 베이스 이미지
+FROM openjdk:17-jdk-alpine
+
+# 빌드 결과 jar 파일 경로 설정
+ARG JAR_FILE=build/libs/*.jar
+
+# JAR 복사
+COPY ${JAR_FILE} app.jar
+
+# 애플리케이션 실행
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/alarm-service/build.gradle
+++ b/alarm-service/build.gradle
@@ -29,12 +29,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.25.2'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'org.postgresql:postgresql'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    implementation 'org.springframework.kafka:spring-kafka'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/alarm-service/src/main/java/com/musinsam/alarmservice/infrastructure/kafka/AlarmKafkaConsumer.java
+++ b/alarm-service/src/main/java/com/musinsam/alarmservice/infrastructure/kafka/AlarmKafkaConsumer.java
@@ -1,0 +1,27 @@
+package com.musinsam.alarmservice.infrastructure.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.musinsam.alarmservice.application.dto.request.ReqAlarmPostDtoApiV1;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class AlarmKafkaConsumer {
+
+  private final ObjectMapper objectMapper;
+
+  @KafkaListener(topics = "coupon.alarm", groupId = "alarm-service-group")
+  public void listen(String message) {
+    try {
+      ReqAlarmPostDtoApiV1 alarmDto = objectMapper.readValue(message, ReqAlarmPostDtoApiV1.class);
+      // 실제 알림 처리 로직
+      log.info("알림 수신: {}", alarmDto.getAlarm().getMessage());
+    } catch (Exception e) {
+      log.error("Kafka 메시지 처리 실패", e);
+    }
+  }
+}

--- a/alarm-service/src/main/resources/application.yml
+++ b/alarm-service/src/main/resources/application.yml
@@ -21,6 +21,12 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 10
+  kafka:
+    consumer:
+      bootstrap-servers: localhost:9092
+      group-id: alarm-service-group
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
 springdoc:
   api-docs:

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -103,6 +103,52 @@ services:
     networks:
       - laboratory-network
 
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.0
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:7.4.0
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://kafka:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT_INTERNAL
+    depends_on:
+      - zookeeper
+
+  alarm-service:
+    build:
+      context: ../alarm-service
+    container_name: alarm-service
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+    depends_on:
+      - kafka
+    ports:
+      - "14001:10000"
+
+  shop-service:
+    build:
+      context: ../shop-service
+    container_name: shop-service
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+    depends_on:
+      - kafka
+    ports:
+      - "11003:10000"
+
 volumes:
   postgres_data:
   grafana-storage:

--- a/shop-service/Dockerfile
+++ b/shop-service/Dockerfile
@@ -1,0 +1,11 @@
+# 베이스 이미지
+FROM openjdk:17-jdk-alpine
+
+# 빌드 결과 jar 파일 경로 설정
+ARG JAR_FILE=build/libs/*.jar
+
+# JAR 복사
+COPY ${JAR_FILE} app.jar
+
+# 애플리케이션 실행
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/shop-service/build.gradle
+++ b/shop-service/build.gradle
@@ -55,14 +55,59 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    implementation 'org.springframework.kafka:spring-kafka'
+
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:3.0.0'
     testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.2'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
 }
 
 dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
+ext {
+    serviceId = 'shop-service'
+    apiTitle = 'Shop Service API'
+    apiVersion = project.version
+    apiDescription = 'Shop Service API'
+}
+
+openapi3 {
+    servers = [
+            {
+                url = "http://localhost:10000"
+            }
+    ]
+    title = 'Shop Service'
+    version = '1.0.0'
+    description = ''
+    format = 'json'
+}
+
+tasks.register('setDocs') {
+    dependsOn 'openapi3'
+    doLast {
+        copy {
+            from "build/api-spec"
+            include "*.json"
+            include "*.yaml"
+            into "build/resources/main/static/springdoc"
+            rename { String fileName ->
+                if (fileName.endsWith('.json')) {
+                    return fileName.replace('.json', '-shop-service.json')
+                } else if (fileName.endsWith('.yaml')) {
+                    return fileName.replace('.yaml', '-shop-service.yml')
+                }
+                return fileName
+            }
+        }
     }
 }
 
@@ -86,4 +131,16 @@ tasks.withType(JavaCompile).configureEach {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+compileJava {
+    dependsOn 'clean'
+}
+
+bootRun {
+    dependsOn 'setDocs'
+}
+
+bootJar {
+    dependsOn 'setDocs'
 }

--- a/shop-service/src/main/java/com/musinsam/shopservice/ShopServiceApplication.java
+++ b/shop-service/src/main/java/com/musinsam/shopservice/ShopServiceApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableFeignClients
+@EnableScheduling
 @EnableDiscoveryClient
+@EnableFeignClients
 @SpringBootApplication
 public class ShopServiceApplication {
 

--- a/shop-service/src/main/java/com/musinsam/shopservice/application/dto/request/ReqAiPostDtoApiV1.java
+++ b/shop-service/src/main/java/com/musinsam/shopservice/application/dto/request/ReqAiPostDtoApiV1.java
@@ -1,0 +1,31 @@
+package com.musinsam.shopservice.application.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReqAiPostDtoApiV1 {
+
+  @Valid
+  @NotNull(message = "Ai 정보를 입력해주세요.")
+  private Ai ai;
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Ai {
+
+    @NotBlank(message = "요청 메시지를 입력해주세요.")
+    private String prompt;
+
+  }
+}

--- a/shop-service/src/main/java/com/musinsam/shopservice/application/dto/request/ReqAlarmPostDtoApiV1.java
+++ b/shop-service/src/main/java/com/musinsam/shopservice/application/dto/request/ReqAlarmPostDtoApiV1.java
@@ -1,0 +1,31 @@
+package com.musinsam.shopservice.application.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReqAlarmPostDtoApiV1 {
+
+  @Valid
+  @NotNull(message = "알림 정보를 입력해주세요.")
+  private Alarm alarm;
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Alarm {
+
+    @NotBlank(message = "메시지를 입력해주세요.")
+    private String message;
+
+  }
+}

--- a/shop-service/src/main/java/com/musinsam/shopservice/application/dto/response/ResAlarmPostDtoApiV1.java
+++ b/shop-service/src/main/java/com/musinsam/shopservice/application/dto/response/ResAlarmPostDtoApiV1.java
@@ -1,0 +1,28 @@
+package com.musinsam.shopservice.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResAlarmPostDtoApiV1 {
+
+  private Alarm alarm;
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Alarm {
+
+    @JsonProperty
+    private UUID id;
+
+  }
+}

--- a/shop-service/src/main/java/com/musinsam/shopservice/application/service/ShopServiceApiV1.java
+++ b/shop-service/src/main/java/com/musinsam/shopservice/application/service/ShopServiceApiV1.java
@@ -10,10 +10,8 @@ import com.musinsam.shopservice.application.dto.response.ResShopGetDtoApiV1;
 import com.musinsam.shopservice.application.dto.response.ResShopPostDtoApiV1;
 import com.musinsam.shopservice.application.dto.response.ResShopPutByShopIdDtoApiV1;
 import com.musinsam.shopservice.domain.shop.entity.ShopEntity;
-import com.musinsam.shopservice.domain.shop.repository.ShopQueryRepository;
 import com.musinsam.shopservice.domain.shop.repository.ShopRepository;
 import com.musinsam.shopservice.infrastructure.excepcion.ShopErrorCode;
-import com.musinsam.shopservice.infrastructure.feign.CouponFeignClientApiV1;
 import java.time.ZoneId;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -27,8 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class ShopServiceApiV1 {
 
   private final ShopRepository shopRepository;
-  private final ShopQueryRepository shopQueryRepository;
-  private final CouponFeignClientApiV1 couponFeignClientApiV1;
 
   @Transactional
   public ResShopPostDtoApiV1 postBy(ReqShopPostDtoApiV1 dto, CurrentUserDtoApiV1 currentUser) {

--- a/shop-service/src/main/java/com/musinsam/shopservice/infrastructure/feign/AiFeignClientApiV1.java
+++ b/shop-service/src/main/java/com/musinsam/shopservice/infrastructure/feign/AiFeignClientApiV1.java
@@ -1,7 +1,7 @@
 package com.musinsam.shopservice.infrastructure.feign;
 
 import com.musinsam.common.config.FeignConfig;
-import com.musinsam.common.response.ApiResponse;
+import com.musinsam.shopservice.application.dto.request.ReqAiPostDtoApiV1;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,6 +10,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface AiFeignClientApiV1 {
 
   @PostMapping("/internal/v1/ai-messages")
-  ApiResponse<String> getCompletions(@RequestBody String request);
+  String postBy(@RequestBody ReqAiPostDtoApiV1 dto);
 
 }

--- a/shop-service/src/main/java/com/musinsam/shopservice/infrastructure/feign/AlarmFeignClientApiV1.java
+++ b/shop-service/src/main/java/com/musinsam/shopservice/infrastructure/feign/AlarmFeignClientApiV1.java
@@ -1,0 +1,16 @@
+package com.musinsam.shopservice.infrastructure.feign;
+
+import com.musinsam.common.config.FeignConfig;
+import com.musinsam.shopservice.application.dto.request.ReqAlarmPostDtoApiV1;
+import com.musinsam.shopservice.application.dto.response.ResAlarmPostDtoApiV1;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "alarm-service", configuration = FeignConfig.class)
+public interface AlarmFeignClientApiV1 {
+
+  @PostMapping("/internal/v1/slack-alarms")
+  ResponseEntity<ResAlarmPostDtoApiV1> postBy(@RequestBody ReqAlarmPostDtoApiV1 dto);
+}

--- a/shop-service/src/main/java/com/musinsam/shopservice/infrastructure/kafka/AlarmKafkaProducer.java
+++ b/shop-service/src/main/java/com/musinsam/shopservice/infrastructure/kafka/AlarmKafkaProducer.java
@@ -1,0 +1,30 @@
+package com.musinsam.shopservice.infrastructure.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.musinsam.shopservice.application.dto.request.ReqAlarmPostDtoApiV1;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class AlarmKafkaProducer {
+
+  private final KafkaTemplate<String, String> kafkaTemplate;
+  private final ObjectMapper objectMapper;
+
+  private static final String TOPIC = "coupon.alarm";
+
+  public void sendAlarm(ReqAlarmPostDtoApiV1 alarmDto) {
+    try {
+      String message = objectMapper.writeValueAsString(alarmDto);
+      kafkaTemplate.send(TOPIC, message);
+      log.info("Kafka 알림 전송 성공: {}", message);
+    } catch (JsonProcessingException e) {
+      log.error("Kafka 알림 직렬화 실패", e);
+    }
+  }
+}

--- a/shop-service/src/main/java/com/musinsam/shopservice/infrastructure/scheduler/WeeklyCouponBatch.java
+++ b/shop-service/src/main/java/com/musinsam/shopservice/infrastructure/scheduler/WeeklyCouponBatch.java
@@ -1,0 +1,121 @@
+package com.musinsam.shopservice.infrastructure.scheduler;
+
+import com.musinsam.shopservice.application.dto.request.ReqAiPostDtoApiV1;
+import com.musinsam.shopservice.application.dto.request.ReqAlarmPostDtoApiV1;
+import com.musinsam.shopservice.application.dto.response.ResShopCouponDtoApiV1;
+import com.musinsam.shopservice.application.service.ShopInternalServiceApiV1;
+import com.musinsam.shopservice.infrastructure.feign.AiFeignClientApiV1;
+import com.musinsam.shopservice.infrastructure.kafka.AlarmKafkaProducer;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public abstract class WeeklyCouponBatch {
+
+  private final ShopInternalServiceApiV1 shopInternalServiceApiV1;
+  private final AiFeignClientApiV1 aiFeignClientApiV1;
+  private final AlarmKafkaProducer alarmKafkaProducer;
+
+  // 매주 월요일 오전 3시에 실행
+  @Scheduled(cron = "0 0 3 ? * MON")
+//  @Scheduled(cron = "0 0/1 * * * *") // 테스트용
+  public void runWeeklyCouponCheck() {
+    List<UUID> shopIds = getShopIds();
+    int totalShopCount = shopIds.size(); // 전체 상점 수
+    int totalCouponCount = 0; // 전체 쿠폰 수
+    int processedShopCount = 0; // 실제 처리된 상점 수
+    long totalStart = System.currentTimeMillis();
+    int count = 0;
+
+    for (UUID shopId : shopIds) {
+      try {
+        long start = System.currentTimeMillis();
+        log.info("쿠폰 조회 시작 - shopId: {}", shopId);
+        // 쿠폰 조회
+        ResShopCouponDtoApiV1 res = shopInternalServiceApiV1.internalCouponGetByShopId(shopId);
+
+        // 조회된 쿠폰이 null이 아니고, couponList가 비어있지 않다면 진행
+        if (res != null && res.getCouponList() != null && !res.getCouponList().isEmpty()) {
+          for (ResShopCouponDtoApiV1.Coupon coupon : res.getCouponList()) {
+            try {
+              ReqAiPostDtoApiV1 aiRequest = buildAiPrompt(coupon, shopId);
+              String slackMessage = aiFeignClientApiV1.postBy(aiRequest);
+
+              log.info("AI 응답 메시지: {}", slackMessage);
+
+              ReqAlarmPostDtoApiV1 slackDto = ReqAlarmPostDtoApiV1.builder()
+                  .alarm(ReqAlarmPostDtoApiV1.Alarm.builder()
+                      .message(slackMessage)
+                      .build())
+                  .build();
+
+              alarmKafkaProducer.sendAlarm(slackDto);
+
+              log.info("Slack 알림 전송 완료: shopId={}, couponId={}, message={}",
+                  shopId, coupon.getCouponId(), slackMessage);
+
+            } catch (Exception innerEx) {
+              log.error("개별 쿠폰 메시지 전송 실패: shopId={}, couponId={}", shopId, coupon.getCouponId(),
+                  innerEx);
+            }
+            totalCouponCount++;
+          }
+          long end = System.currentTimeMillis();
+          log.info("shopId={}, took {}ms", shopId, end - start);
+          processedShopCount++; // 쿠폰 있는 상점
+        } else {
+          // 쿠폰이 없거나 비어있는 경우에는 추가 로그를 출력하고 넘어가도록 처리
+          log.info("쿠폰이 없거나 비어있음: shopId={}", shopId);
+        }
+
+      } catch (Exception e) {
+        log.error("쿠폰 알림 배치 실패: shopId={}", shopId, e);
+      }
+    }
+    long totalEnd = System.currentTimeMillis();
+    long totalTime = totalEnd - totalStart;
+    log.info("전체 소요 시간: {}ms, 상점 수: {}, 처리된 상점 수: {}, 총 쿠폰 수: {}, 평균 처리 시간: {}ms",
+        totalTime, totalShopCount, processedShopCount, totalCouponCount,
+        processedShopCount == 0 ? 0 : totalTime / processedShopCount);
+  }
+
+  private ReqAiPostDtoApiV1 buildAiPrompt(ResShopCouponDtoApiV1.Coupon coupon, UUID shopId) {
+    var policy = coupon.getCouponPolicy();
+
+    if (policy == null) {
+      throw new IllegalArgumentException("쿠폰 정책 정보가 없습니다.");
+    }
+
+    String prompt = String.format("""
+            상점 ID: %s
+            쿠폰 ID: %s
+            쿠폰명: %s
+            유효기간: %s ~ %s 까지
+            
+            이 쿠폰 정보를 바탕으로 고객에게 Slack 알림 메시지를 보낼 수 있도록 자연스러운 마케팅 문구를 생성해 주세요.
+            """,
+        shopId,
+        coupon.getCouponId(),
+        coupon.getCouponName(),
+        policy.getStartTime(),
+        policy.getEndTime()
+    );
+
+    log.info("AI 프롬프트 생성 완료: shopId={}, couponId={}", shopId, coupon.getCouponId());
+
+    return ReqAiPostDtoApiV1.builder()
+        .ai(ReqAiPostDtoApiV1.Ai.builder()
+            .prompt(prompt)
+            .build())
+        .build();
+  }
+
+  // 구현체에서 정의
+  protected abstract List<UUID> getShopIds();
+}

--- a/shop-service/src/main/java/com/musinsam/shopservice/infrastructure/scheduler/WeeklyCouponBatchImpl.java
+++ b/shop-service/src/main/java/com/musinsam/shopservice/infrastructure/scheduler/WeeklyCouponBatchImpl.java
@@ -1,0 +1,39 @@
+package com.musinsam.shopservice.infrastructure.scheduler;
+
+import com.musinsam.shopservice.application.dto.response.ResInternalShopGetDtoApiV1;
+import com.musinsam.shopservice.application.dto.response.ResInternalShopGetDtoApiV1.ShopPage.Shop;
+import com.musinsam.shopservice.application.service.ShopInternalServiceApiV1;
+import com.musinsam.shopservice.infrastructure.feign.AiFeignClientApiV1;
+import com.musinsam.shopservice.infrastructure.kafka.AlarmKafkaProducer;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WeeklyCouponBatchImpl extends WeeklyCouponBatch {
+
+  private final ShopInternalServiceApiV1 shopInternalServiceApiV1;
+
+  // 생성자 주입을 위해 부모 클래스의 생성자에도 넘겨줌
+  public WeeklyCouponBatchImpl(
+      ShopInternalServiceApiV1 shopInternalServiceApiV1,
+      AiFeignClientApiV1 aiFeignClientApiV1,
+      AlarmKafkaProducer alarmKafkaProducer
+  ) {
+    super(shopInternalServiceApiV1, aiFeignClientApiV1, alarmKafkaProducer);
+    this.shopInternalServiceApiV1 = shopInternalServiceApiV1;
+  }
+
+  @Override
+  protected List<UUID> getShopIds() {
+    // 최대 100개 상점만 페이징 조회
+    PageRequest pageable = PageRequest.of(0, 100);
+    ResInternalShopGetDtoApiV1 res = shopInternalServiceApiV1.internalGetShopList(pageable);
+
+    return res.getShopPage().getContent().stream() // PagedModel의 getContent()
+        .map(Shop::getId)
+        .collect(Collectors.toList());
+  }
+}

--- a/shop-service/src/main/java/com/musinsam/shopservice/presentation/controller/WeeklyCouponBatchControllerV1.java
+++ b/shop-service/src/main/java/com/musinsam/shopservice/presentation/controller/WeeklyCouponBatchControllerV1.java
@@ -1,0 +1,22 @@
+package com.musinsam.shopservice.presentation.controller;
+
+import com.musinsam.shopservice.infrastructure.scheduler.WeeklyCouponBatchImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/v1/shops/batch")
+public class WeeklyCouponBatchControllerV1 {
+
+  private final WeeklyCouponBatchImpl weeklyCouponBatchImpl;
+
+  @PostMapping("/weekly-coupon")
+  public ResponseEntity<String> runWeeklyCouponBatch() {
+    weeklyCouponBatchImpl.runWeeklyCouponCheck(); // 직접 실행
+    return ResponseEntity.ok("Batch triggered successfully");
+  }
+}

--- a/shop-service/src/main/resources/application.yml
+++ b/shop-service/src/main/resources/application.yml
@@ -21,6 +21,15 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 10
+  task:
+    scheduling:
+      pool:
+        size: 2
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
 springdoc:
   api-docs:

--- a/shop-service/src/test/java/http/Shop.http
+++ b/shop-service/src/test/java/http/Shop.http
@@ -94,3 +94,9 @@ Authorization: Bearer {{accessToken}}
 GET http://localhost:10000/internal/v1/shops/coupons?shopId=af80aa19-9c74-49dc-b115-8f4533de0f7b
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
+
+### 배치 실행 API (테스트용)
+POST http://localhost:10000/internal/v1/shops/batch/weekly-coupon
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+


### PR DESCRIPTION
## #️⃣연관된 이슈

- #219 

## 📝작업 내용

> 상점에서 Scheduling 적용해서 쿠폰 조회 후,
> Ai로 Alarm을 생성하고. Slack으로 알림 전송
> docker-compose 수정
> batch 구현
> kafka 적용
> shop build.gradle swagger 적용

## 💬리뷰 요구사항(선택)

> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - alarm-service와 shop-service에 대한 Docker 이미지 빌드 및 실행 환경이 추가되었습니다.
  - Kafka 및 Zookeeper 인프라가 docker-compose에 추가되어 메시징 기반 연동이 가능해졌습니다.
  - shop-service에 주간 쿠폰 배치 작업이 추가되어 매주 월요일 3시에 자동 실행됩니다.
  - 주간 쿠폰 배치를 수동으로 실행할 수 있는 내부 API 엔드포인트가 추가되었습니다.
  - 알람 및 AI 메시지 전송을 위한 Kafka 프로듀서/컨슈머, Feign Client, DTO가 shop-service와 alarm-service에 도입되었습니다.

- **버그 수정**
  - 해당 사항 없음.

- **문서화**
  - shop-service의 OpenAPI 문서 자동 생성 및 배포가 빌드 과정에 통합되었습니다.
  - 배치 API 테스트용 HTTP 요청 예제가 추가되었습니다.

- **환경설정**
  - Kafka, 스케줄링, 테스트 관련 설정이 application.yml에 추가되었습니다.

- **리팩터링**
  - shop-service의 일부 서비스 클래스에서 불필요한 의존성이 제거되었습니다.
  - Feign Client 및 DTO 구조가 명확하게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->