### PR TITLE
[Alarm] Slack 알림봇 1:1 DM 전송 서비스 구현

### DIFF
--- a/alarm-service/src/main/java/com/musinsam/alarmservice/application/dto/response/SlackOpenImResponse.java
+++ b/alarm-service/src/main/java/com/musinsam/alarmservice/application/dto/response/SlackOpenImResponse.java
@@ -1,0 +1,16 @@
+package com.musinsam.alarmservice.application.dto.response;
+
+import lombok.Data;
+
+@Data
+public class SlackOpenImResponse {
+
+  private boolean ok;
+  private Channel channel;
+
+  @Data
+  public static class Channel {
+
+    private String id;
+  }
+}

--- a/alarm-service/src/main/java/com/musinsam/alarmservice/application/service/AlarmInternalServiceApiV1.java
+++ b/alarm-service/src/main/java/com/musinsam/alarmservice/application/service/AlarmInternalServiceApiV1.java
@@ -10,7 +10,6 @@ import com.musinsam.alarmservice.domain.alarm.repository.AlarmRepository;
 import com.musinsam.alarmservice.infrastructure.exception.AlarmErrorCode;
 import com.musinsam.alarmservice.infrastructure.feign.SlackFeignClientApiV1;
 import com.musinsam.common.exception.CustomException;
-import com.musinsam.common.user.CurrentUserDtoApiV1;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -20,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class AlarmServiceApiV1 {
+public class AlarmInternalServiceApiV1 {
 
   private final AlarmRepository alarmRepository;
   private final SlackFeignClientApiV1 slackFeignClientApiV1;

--- a/alarm-service/src/main/java/com/musinsam/alarmservice/application/service/SlackService.java
+++ b/alarm-service/src/main/java/com/musinsam/alarmservice/application/service/SlackService.java
@@ -1,0 +1,29 @@
+package com.musinsam.alarmservice.application.service;
+
+import com.musinsam.alarmservice.application.dto.response.SlackOpenImResponse;
+import com.musinsam.alarmservice.infrastructure.feign.SlackFeignClientApiV2;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SlackService {
+
+  private final SlackFeignClientApiV2 slackFeignClientApiV2;
+
+  public void sendDmToUser(String userId, String message) {
+    // 1. DM 채널 오픈
+    Map<String, Object> openRequest = Map.of("users", userId);
+    SlackOpenImResponse openResponse = slackFeignClientApiV2.openImChannel(openRequest);
+
+    String channelId = openResponse.getChannel().getId();
+
+    // 2. 메시지 전송
+    Map<String, Object> messageRequest = Map.of(
+        "channel", channelId,
+        "text", message
+    );
+    slackFeignClientApiV2.postMessage(messageRequest);
+  }
+}

--- a/alarm-service/src/main/java/com/musinsam/alarmservice/application/service/SlackService.java
+++ b/alarm-service/src/main/java/com/musinsam/alarmservice/application/service/SlackService.java
@@ -14,6 +14,12 @@ public class SlackService {
 
   private final SlackFeignClientApiV2 slackFeignClientApiV2;
 
+  /**
+   * Sends a direct message to a specified Slack user.
+   *
+   * @param userId the Slack user ID to whom the message will be sent
+   * @param message the message content to send
+   */
   public void sendDmToUser(String userId, String message) {
     log.info("Slack DM 전송 시작 - 대상 사용자: {}", userId);
     // 1. DM 채널 오픈

--- a/alarm-service/src/main/java/com/musinsam/alarmservice/application/service/SlackService.java
+++ b/alarm-service/src/main/java/com/musinsam/alarmservice/application/service/SlackService.java
@@ -4,26 +4,34 @@ import com.musinsam.alarmservice.application.dto.response.SlackOpenImResponse;
 import com.musinsam.alarmservice.infrastructure.feign.SlackFeignClientApiV2;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SlackService {
 
   private final SlackFeignClientApiV2 slackFeignClientApiV2;
 
   public void sendDmToUser(String userId, String message) {
+    log.info("Slack DM 전송 시작 - 대상 사용자: {}", userId);
     // 1. DM 채널 오픈
     Map<String, Object> openRequest = Map.of("users", userId);
+    log.debug("Slack 채널 오픈 요청: {}", openRequest);
     SlackOpenImResponse openResponse = slackFeignClientApiV2.openImChannel(openRequest);
+    log.debug("Slack 채널 오픈 응답: {}", openResponse);
 
     String channelId = openResponse.getChannel().getId();
+    log.info("Slack 채널 오픈 성공 - 채널 ID: {}", channelId);
 
     // 2. 메시지 전송
     Map<String, Object> messageRequest = Map.of(
         "channel", channelId,
         "text", message
     );
+    log.debug("Slack 메시지 전송 요청: {}", messageRequest);
     slackFeignClientApiV2.postMessage(messageRequest);
+    log.info("Slack DM 전송 완료 - 채널: {}", channelId);
   }
 }

--- a/alarm-service/src/main/java/com/musinsam/alarmservice/infrastructure/config/SlackFeignConfig.java
+++ b/alarm-service/src/main/java/com/musinsam/alarmservice/infrastructure/config/SlackFeignConfig.java
@@ -1,0 +1,21 @@
+package com.musinsam.alarmservice.infrastructure.config;
+
+import feign.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SlackFeignConfig {
+
+  @Value("${slack.bot-token}")
+  private String botToken;
+
+  @Bean
+  public RequestInterceptor slackRequestInterceptor() {
+    return requestTemplate -> {
+      requestTemplate.header("Authorization", "Bearer " + botToken);
+      requestTemplate.header("Content-Type", "application/json");
+    };
+  }
+}

--- a/alarm-service/src/main/java/com/musinsam/alarmservice/infrastructure/config/SlackFeignConfig.java
+++ b/alarm-service/src/main/java/com/musinsam/alarmservice/infrastructure/config/SlackFeignConfig.java
@@ -11,6 +11,13 @@ public class SlackFeignConfig {
   @Value("${slack.bot-token}")
   private String botToken;
 
+  /**
+   * Creates a Feign RequestInterceptor that adds Slack authentication and content type headers to outgoing requests.
+   *
+   * The interceptor sets the "Authorization" header with the Slack bot token and the "Content-Type" header to "application/json" for all Feign client requests.
+   *
+   * @return a RequestInterceptor that configures Slack API request headers
+   */
   @Bean
   public RequestInterceptor slackRequestInterceptor() {
     return requestTemplate -> {

--- a/alarm-service/src/main/java/com/musinsam/alarmservice/infrastructure/feign/SlackFeignClientApiV1.java
+++ b/alarm-service/src/main/java/com/musinsam/alarmservice/infrastructure/feign/SlackFeignClientApiV1.java
@@ -9,6 +9,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 @FeignClient(name = "slackClient1", url = "${slack.webhook.url}${slack.webhook.key}")
 public interface SlackFeignClientApiV1 {
 
+  /**
+   * Sends a message to a Slack webhook endpoint.
+   *
+   * @param message the Slack message payload to send
+   * @return the HTTP response from the Slack webhook
+   */
   @PostMapping
   ResponseEntity<String> sendSlack(@RequestBody SlackRequest message);
 }

--- a/alarm-service/src/main/java/com/musinsam/alarmservice/infrastructure/feign/SlackFeignClientApiV1.java
+++ b/alarm-service/src/main/java/com/musinsam/alarmservice/infrastructure/feign/SlackFeignClientApiV1.java
@@ -6,7 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@FeignClient(name = "slackClient", url = "${slack.webhook.url}${slack.webhook.key}")
+@FeignClient(name = "slackClient1", url = "${slack.webhook.url}${slack.webhook.key}")
 public interface SlackFeignClientApiV1 {
 
   @PostMapping

--- a/alarm-service/src/main/java/com/musinsam/alarmservice/infrastructure/feign/SlackFeignClientApiV2.java
+++ b/alarm-service/src/main/java/com/musinsam/alarmservice/infrastructure/feign/SlackFeignClientApiV2.java
@@ -1,0 +1,18 @@
+package com.musinsam.alarmservice.infrastructure.feign;
+
+import com.musinsam.alarmservice.application.dto.response.SlackOpenImResponse;
+import com.musinsam.alarmservice.infrastructure.config.SlackFeignConfig;
+import java.util.Map;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "slackClient2", url = "https://slack.com/api", configuration = SlackFeignConfig.class)
+public interface SlackFeignClientApiV2 {
+
+  @PostMapping("/conversations.open")
+  SlackOpenImResponse openImChannel(@RequestBody Map<String, Object> request);
+
+  @PostMapping("/chat.postMessage")
+  void postMessage(@RequestBody Map<String, Object> request);
+}

--- a/alarm-service/src/main/java/com/musinsam/alarmservice/infrastructure/feign/SlackFeignClientApiV2.java
+++ b/alarm-service/src/main/java/com/musinsam/alarmservice/infrastructure/feign/SlackFeignClientApiV2.java
@@ -10,9 +10,20 @@ import org.springframework.web.bind.annotation.RequestBody;
 @FeignClient(name = "slackClient2", url = "https://slack.com/api", configuration = SlackFeignConfig.class)
 public interface SlackFeignClientApiV2 {
 
+  /**
+   * Opens a direct message channel in Slack using the provided request payload.
+   *
+   * @param request the payload containing parameters required by the Slack API to open a conversation
+   * @return the response from Slack containing details about the opened IM channel
+   */
   @PostMapping("/conversations.open")
   SlackOpenImResponse openImChannel(@RequestBody Map<String, Object> request);
 
+  /**
+   * Sends a message to a Slack channel using the chat.postMessage API endpoint.
+   *
+   * @param request a map containing the message payload and parameters required by Slack's API
+   */
   @PostMapping("/chat.postMessage")
   void postMessage(@RequestBody Map<String, Object> request);
 }

--- a/alarm-service/src/main/java/com/musinsam/alarmservice/presentation/controller/AlarmInternalControllerApiV1.java
+++ b/alarm-service/src/main/java/com/musinsam/alarmservice/presentation/controller/AlarmInternalControllerApiV1.java
@@ -26,16 +26,34 @@ public class AlarmInternalControllerApiV1 {
 
   private final AlarmInternalServiceApiV1 alarmInternalServiceApiV1;
 
+  /**
+   * Creates a new alarm using the provided request data.
+   *
+   * @param dto the alarm creation request payload
+   * @return the created alarm information wrapped in a response entity
+   */
   @PostMapping
   public ResponseEntity<ResAlarmPostDtoApiV1> postBy(@Valid @RequestBody ReqAlarmPostDtoApiV1 dto) {
     return ResponseEntity.ok(alarmInternalServiceApiV1.postBy(dto));
   }
 
+  /**
+   * Retrieves a paginated list of alarms.
+   *
+   * @param pageable pagination and sorting information
+   * @return a response entity containing the paginated alarm data
+   */
   @GetMapping
   public ResponseEntity<ResAlarmGetDtoApiV1> getBy(@Valid Pageable pageable) {
     return ResponseEntity.ok(alarmInternalServiceApiV1.getBy(pageable));
   }
 
+  /**
+   * Retrieves the details of a specific alarm by its UUID.
+   *
+   * @param id the unique identifier of the alarm to retrieve
+   * @return a ResponseEntity containing the alarm details
+   */
   @GetMapping("/{id}")
   public ResponseEntity<ResAlarmGetByIdDtoApiV1> getById(@Valid @PathVariable UUID id) {
     return ResponseEntity.ok(alarmInternalServiceApiV1.getById(id));

--- a/alarm-service/src/main/java/com/musinsam/alarmservice/presentation/controller/AlarmInternalControllerApiV1.java
+++ b/alarm-service/src/main/java/com/musinsam/alarmservice/presentation/controller/AlarmInternalControllerApiV1.java
@@ -4,9 +4,7 @@ import com.musinsam.alarmservice.application.dto.request.ReqAlarmPostDtoApiV1;
 import com.musinsam.alarmservice.application.dto.response.ResAlarmGetByIdDtoApiV1;
 import com.musinsam.alarmservice.application.dto.response.ResAlarmGetDtoApiV1;
 import com.musinsam.alarmservice.application.dto.response.ResAlarmPostDtoApiV1;
-import com.musinsam.alarmservice.application.service.AlarmServiceApiV1;
-import com.musinsam.common.resolver.CurrentUser;
-import com.musinsam.common.user.CurrentUserDtoApiV1;
+import com.musinsam.alarmservice.application.service.AlarmInternalServiceApiV1;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -26,20 +24,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/internal/v1/slack-alarms")
 public class AlarmInternalControllerApiV1 {
 
-  private final AlarmServiceApiV1 alarmServiceApiV1;
+  private final AlarmInternalServiceApiV1 alarmInternalServiceApiV1;
 
   @PostMapping
   public ResponseEntity<ResAlarmPostDtoApiV1> postBy(@Valid @RequestBody ReqAlarmPostDtoApiV1 dto) {
-    return ResponseEntity.ok(alarmServiceApiV1.postBy(dto));
+    return ResponseEntity.ok(alarmInternalServiceApiV1.postBy(dto));
   }
 
   @GetMapping
   public ResponseEntity<ResAlarmGetDtoApiV1> getBy(@Valid Pageable pageable) {
-    return ResponseEntity.ok(alarmServiceApiV1.getBy(pageable));
+    return ResponseEntity.ok(alarmInternalServiceApiV1.getBy(pageable));
   }
 
   @GetMapping("/{id}")
   public ResponseEntity<ResAlarmGetByIdDtoApiV1> getById(@Valid @PathVariable UUID id) {
-    return ResponseEntity.ok(alarmServiceApiV1.getById(id));
+    return ResponseEntity.ok(alarmInternalServiceApiV1.getById(id));
   }
 }

--- a/alarm-service/src/main/resources/application.yml
+++ b/alarm-service/src/main/resources/application.yml
@@ -47,7 +47,7 @@ management:
 slack:
   webhook:
     url: https://hooks.slack.com/services/
-    key: T08LC8E12F8/B08MBTX27V4/rRjOPIGYtpj6R8DNwdZkauJR
+    key: ${WEBHOOK-KEY}
     "display_information":
       "name": "Musinsam Alarmbot"
     "settings":

--- a/alarm-service/src/main/resources/application.yml
+++ b/alarm-service/src/main/resources/application.yml
@@ -55,6 +55,15 @@ slack:
       "socket_mode_enabled": false,
       "is_hosted": false,
       "token_rotation_enabled": false
+  userlist:
+    url: https://slack.com/api/users.list
+  conversations:
+    open:
+      url: https://slack.com/api/conversations.open
+  chat:
+    postMessage:
+      url: https://slack.com/api/chat.postMessage
+  bot-token: ${BOT-TOKEN}
 
 eureka:
   client:

--- a/alarm-service/src/test/java/http/Alarm.http
+++ b/alarm-service/src/test/java/http/Alarm.http
@@ -35,7 +35,7 @@ Authorization: Bearer {{accessToken}}
 
 {
   "alarm": {
-    "message": "Name: John Doe\nEmail: johndoe@example.com\nPhone Number: 555-555-5555\n Order Number: 1234\nOrder Total: $50.00\nMessage: Urgent - Please check on the status of my order.\n\n"
+    "message": "오늘부터 2025년 5월 31일까지, 선착순으로 제공되는 쿠폰이 등장했습니다! 지금 이 매장에서 쇼핑을 하시면, 15% 할인 혜택을 누리실 수 있어요. 얼른 확인해보세요!"
   }
 }
 
@@ -48,3 +48,20 @@ Authorization: Bearer {{accessToken}}
 GET http://localhost:10000/internal/v1/slack-alarms/76a5abec-741d-403d-b6c5-3a2f01f802ff
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
+
+### 슬랙 USERID 조회
+GET https://slack.com/api/users.lookupByEmail?email=soo0864@gmail.com
+Authorization: Bearer {{botToken}}
+
+### 슬랙 전체 유저 리스트에서 찾기
+GET https://slack.com/api/users.list
+Authorization: Bearer {{botToken}}
+
+### 슬랙 DM 채널 열기
+POST https://slack.com/api/conversations.open
+Authorization: Bearer {{botToken}}
+Content-Type: application/json
+
+{
+  "users": "U08LC8E2JVC"
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #224 

## 📝작업 내용

> Slack 알림봇 1:1 DM 전송 서비스 구현
> Internal 구조 수정
> httpClient test 추가

## 💬리뷰 요구사항(선택)

> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
  - 슬랙 사용자에게 다이렉트 메시지를 전송하는 기능이 추가되었습니다.
  - 슬랙 API 연동을 위한 서비스, Feign 클라이언트 및 응답 모델이 도입되었습니다.

- **설정**
  - 슬랙 API 연동을 위한 엔드포인트 및 봇 토큰 환경변수 설정이 추가되었습니다.

- **테스트**
  - 슬랙 관련 API 테스트 요청이 추가되었습니다.
  - 알람 등록 테스트 메시지가 변경되었습니다.

- **리팩터링**
  - 일부 서비스 및 컨트롤러 클래스 명칭과 의존성이 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->