### PR TITLE
[Order] 주문 확인 요청 및 복구 

### DIFF
--- a/infrastructure/k6-scripts/order-api-stress-test.js
+++ b/infrastructure/k6-scripts/order-api-stress-test.js
@@ -7,12 +7,11 @@ const userRole = __ENV.TEST_USER_ROLE;
 
 export const options = {
   scenarios: {
-    ramping_test: {
-      executor: 'per-vu-iterations',
-      vus: 1000,
-      iterations: 10,
-      startTime: '0s',
-      maxDuration: '1m',
+    concurrent_requests: {
+      executor: 'constant-vus',
+      vus: 100,
+      duration: '10s',
+      gracefulStop: '5s'
     },
   },
 };
@@ -64,7 +63,6 @@ export default function () {
   const response = http.post(url, payload, params);
 
   check(response, {
-    'status is 200': (r) => r.status === 200,
-    'response time < 500ms': (r) => r.timings.duration < 500
+    'status is 200': (r) => r.status === 200
   });
 }

--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -26,6 +26,9 @@ ext {
 dependencies {
     implementation project(':common')
 
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+    implementation "org.springframework.boot:spring-boot-starter-aop"
+
     // prometheus dependency
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
@@ -45,6 +48,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderServiceApiV1.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderServiceApiV1.java
@@ -13,6 +13,7 @@ import com.musinsam.orderservice.application.dto.response.ResOrderPutDtoApiV1;
 import com.musinsam.orderservice.domain.order.entity.OrderEntity;
 import com.musinsam.orderservice.domain.order.entity.OrderItemEntity;
 import com.musinsam.orderservice.domain.order.exception.OrderException;
+import com.musinsam.orderservice.domain.order.exception.OrderStockRestoreException;
 import com.musinsam.orderservice.domain.order.repository.OrderRepository;
 import com.musinsam.orderservice.domain.order.vo.OrderErrorCode;
 import com.musinsam.orderservice.domain.order.vo.OrderStatus;
@@ -24,12 +25,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OrderServiceApiV1 {
@@ -139,18 +142,23 @@ public class OrderServiceApiV1 {
   }
 
   private boolean checkAndReduceStock(OrderEntity orderEntity) {
+
+    log.debug("주문 상품 재고 확인 및 차감 시작: 주문 ID={}", orderEntity.getId());
     List<OrderItemEntity> processedItems = new ArrayList<>();
 
     for (OrderItemEntity item : orderEntity.getOrderItems()) {
+      log.debug("상품 재고 차감 시도: 상품 ID={}, 수량={}", item.getProductId(), item.getQuantity());
       boolean success = attemptStockReduction(item);
 
       if (!success) {
+        log.debug("상품 재고 차감 실패, 롤백 시작: 상품 ID={}", item.getProductId());
         rollbackStockReduction(processedItems);
         return false;
       }
 
       processedItems.add(item);
     }
+    log.debug("모든 상품 재고 차감 성공: 주문 ID={}", orderEntity.getId());
     return true;
   }
 
@@ -167,6 +175,14 @@ public class OrderServiceApiV1 {
     return false;
   }
 
+  private boolean stockReductionFallback(OrderItemEntity item, Exception e) {
+
+    log.debug("상품 재고 차감 실패: productId={}, quantity={}, 오류={}",
+        item.getProductId(), item.getQuantity(), e.getMessage());
+    return false;
+
+  }
+
   private void rollbackStockReduction(List<OrderItemEntity> processedItems) {
     if (processedItems.isEmpty()) {
       return;
@@ -179,9 +195,22 @@ public class OrderServiceApiV1 {
 
   private void restoreProductStock(OrderEntity orderEntity) {
     for (OrderItemEntity item : orderEntity.getOrderItems()) {
-      productFeignClient.restoreStock(item.getProductId(), item.getQuantity());
+      ResponseEntity<Void> response = productFeignClient.restoreStock(item.getProductId(),
+          item.getQuantity());
+
+      if (!response.getStatusCode().is2xxSuccessful()) {
+        throw new OrderStockRestoreException();
+      }
     }
   }
+
+  private void restoreProductStockFallback(OrderEntity orderEntity, Exception e) {
+    log.debug("주문 취소 시 재고 복원 실패: 주문 ID={}, 오류={}",
+        orderEntity.getId(), e.getMessage());
+
+    throw new OrderStockRestoreException();
+  }
+
 
   private void validateDeletableStatus(OrderEntity orderEntity) {
     List<OrderStatus> deletableStatuses = List.of(

--- a/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderServiceApiV1.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderServiceApiV1.java
@@ -85,11 +85,13 @@ public class OrderServiceApiV1 {
   @Transactional
   public ResOrderPutDtoApiV1 updateOrderStatus(UUID orderId, ReqOrderPutDtoApiV1 requestDto,
       Long userId) {
-    OrderEntity orderEntity = orderRepository.findByIdWithOrderItems(orderId)
+    OrderEntity orderEntity = orderRepository.findByIdWithOrderItemsForUpdate(orderId)
         .orElseThrow(() -> OrderException.from(OrderErrorCode.ORDER_NOT_FOUND));
 
     validateOrderOwner(orderEntity, userId);
     validateOrderStatus(orderEntity);
+
+    restoreProductStock(orderEntity);
 
     boolean stockAvailable = checkAndReduceStock(orderEntity);
 

--- a/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderServiceApiV1.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderServiceApiV1.java
@@ -48,13 +48,13 @@ public class OrderServiceApiV1 {
     validateOrderOwner(orderEntity, userId);
     validateOrderStatus(orderEntity);
 
+    OrderEntity savedOrder = orderRepository.save(orderEntity);
+
     boolean stockAvailable = checkAndReduceStock(orderEntity);
 
     if (!stockAvailable) {
       throw OrderException.from(OrderErrorCode.ORDER_PRODUCT_NOT_AVAILABLE);
     }
-
-    OrderEntity savedOrder = orderRepository.save(orderEntity);
 
     return ResOrderPostDtoApiV1.of(savedOrder);
   }

--- a/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderServiceApiV1.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderServiceApiV1.java
@@ -16,13 +16,17 @@ import com.musinsam.orderservice.domain.order.exception.OrderException;
 import com.musinsam.orderservice.domain.order.repository.OrderRepository;
 import com.musinsam.orderservice.domain.order.vo.OrderErrorCode;
 import com.musinsam.orderservice.domain.order.vo.OrderStatus;
+import com.musinsam.orderservice.infrastructure.client.ProductFeignClient;
 import com.querydsl.core.types.Predicate;
+import io.github.resilience4j.retry.annotation.Retry;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderServiceApiV1 {
 
   private final OrderRepository orderRepository;
+  private final ProductFeignClient productFeignClient;
 
   @Transactional
   public ResOrderPostDtoApiV1 createOrder(ReqOrderPostDtoApiV1 requestDto, Long userId) {
@@ -40,8 +45,7 @@ public class OrderServiceApiV1 {
     validateOrderOwner(orderEntity, userId);
     validateOrderStatus(orderEntity);
 
-    // TODO: 상품 서비스에 재고 확인 요청 및 차감
-    boolean stockAvailable = true;
+    boolean stockAvailable = checkAndReduceStock(orderEntity);
 
     if (!stockAvailable) {
       throw OrderException.from(OrderErrorCode.ORDER_PRODUCT_NOT_AVAILABLE);
@@ -84,7 +88,7 @@ public class OrderServiceApiV1 {
     validateOrderOwner(orderEntity, userId);
     validateOrderStatus(orderEntity);
 
-    boolean stockAvailable = true;
+    boolean stockAvailable = checkAndReduceStock(orderEntity);
 
     if (!stockAvailable) {
       throw OrderException.from(OrderErrorCode.ORDER_PRODUCT_NOT_AVAILABLE);
@@ -111,7 +115,7 @@ public class OrderServiceApiV1 {
         requestDto.getOrder().getCancelReason()
     );
 
-    // TODO: 재고 복구 요청
+    restoreProductStock(orderEntity);
 
     return ResOrderPostCancelDtoApiV1.of(orderEntity);
   }
@@ -131,6 +135,51 @@ public class OrderServiceApiV1 {
 
     for (OrderItemEntity item : orderEntity.getOrderItems()) {
       item.softDelete(userId, zoneId);
+    }
+  }
+
+  private boolean checkAndReduceStock(OrderEntity orderEntity) {
+    List<OrderItemEntity> processedItems = new ArrayList<>();
+
+    for (OrderItemEntity item : orderEntity.getOrderItems()) {
+      boolean success = attemptStockReduction(item);
+
+      if (!success) {
+        rollbackStockReduction(processedItems);
+        return false;
+      }
+
+      processedItems.add(item);
+    }
+    return true;
+  }
+
+  @Retry(name = "product-service", fallbackMethod = "stockReductionFallback")
+  private boolean attemptStockReduction(OrderItemEntity item) {
+    ResponseEntity<Boolean> response = productFeignClient.checkAndReduceStock(
+        item.getProductId(), item.getQuantity());
+
+    if (response.getStatusCode().is2xxSuccessful() &&
+        Boolean.TRUE.equals(response.getBody())) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private void rollbackStockReduction(List<OrderItemEntity> processedItems) {
+    if (processedItems.isEmpty()) {
+      return;
+    }
+
+    for (OrderItemEntity item : processedItems) {
+      productFeignClient.restoreStock(item.getProductId(), item.getQuantity());
+    }
+  }
+
+  private void restoreProductStock(OrderEntity orderEntity) {
+    for (OrderItemEntity item : orderEntity.getOrderItems()) {
+      productFeignClient.restoreStock(item.getProductId(), item.getQuantity());
     }
   }
 

--- a/order-service/src/main/java/com/musinsam/orderservice/domain/order/exception/OrderStockRestoreException.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/domain/order/exception/OrderStockRestoreException.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 public class OrderStockRestoreException extends OrderException {
 
-  public OrderStockRestoreException(OrderErrorCode errorCode) {
+  public OrderStockRestoreException() {
     super(OrderErrorCode.ORDER_STOCK_RESTORE_FAILED);
   }
 }

--- a/order-service/src/main/java/com/musinsam/orderservice/domain/order/exception/OrderStockRestoreException.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/domain/order/exception/OrderStockRestoreException.java
@@ -1,0 +1,12 @@
+package com.musinsam.orderservice.domain.order.exception;
+
+import com.musinsam.orderservice.domain.order.vo.OrderErrorCode;
+import lombok.Getter;
+
+@Getter
+public class OrderStockRestoreException extends OrderException {
+
+  public OrderStockRestoreException(OrderErrorCode errorCode) {
+    super(OrderErrorCode.ORDER_STOCK_RESTORE_FAILED);
+  }
+}

--- a/order-service/src/main/java/com/musinsam/orderservice/domain/order/repository/OrderRepository.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/domain/order/repository/OrderRepository.java
@@ -13,5 +13,7 @@ public interface OrderRepository {
 
   Optional<OrderEntity> findByIdWithOrderItems(UUID orderId);
 
+  Optional<OrderEntity> findByIdWithOrderItemsForUpdate(UUID orderId);
+
   Page<OrderEntity> findAll(Predicate predicate, Pageable pageable);
 }

--- a/order-service/src/main/java/com/musinsam/orderservice/domain/order/vo/OrderErrorCode.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/domain/order/vo/OrderErrorCode.java
@@ -26,6 +26,8 @@ public enum OrderErrorCode implements ErrorCode {
   ORDER_CANNOT_BE_CANCELED(-1, "Order cannot be canceled",
       HttpStatus.BAD_REQUEST),
   ORDER_CANNOT_BE_DELETED(-1, "Order cannot be deleted",
+      HttpStatus.BAD_REQUEST),
+  ORDER_STOCK_RESTORE_FAILED(-1, "Stock Restore request failed",
       HttpStatus.BAD_REQUEST);
 
   private final Integer code;

--- a/order-service/src/main/java/com/musinsam/orderservice/infrastructure/client/ProductFeignClient.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/infrastructure/client/ProductFeignClient.java
@@ -1,0 +1,41 @@
+package com.musinsam.orderservice.infrastructure.client;
+
+import com.musinsam.common.config.FeignConfig;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+    name = "product-service",
+    configuration = FeignConfig.class,
+    url = "http://localhost:11002"
+)
+public interface ProductFeignClient {
+
+  /**
+   * 상품 재고 확인 및 차감 요청
+   *
+   * @param productId 상품 ID
+   * @param quantity  수량
+   * @return 재고 차감 성공 여부
+   */
+  @PutMapping("/internal/v1/products/stock/reduce")
+  ResponseEntity<Boolean> checkAndReduceStock(
+      @RequestParam UUID productId,
+      @RequestParam Integer quantity
+  );
+
+  /**
+   * 상품 재고 복구 요청
+   *
+   * @param productId 상품 ID
+   * @param quantity  복구할 수량
+   */
+  @PutMapping("/internal/v1/products/stock/restore")
+  ResponseEntity<Void> restoreStock(
+      @RequestParam UUID productId,
+      @RequestParam Integer quantity
+  );
+}

--- a/order-service/src/main/java/com/musinsam/orderservice/infrastructure/client/ProductFeignClient.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/infrastructure/client/ProductFeignClient.java
@@ -9,8 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(
     name = "product-service",
-    configuration = FeignConfig.class,
-    url = "http://localhost:11002"
+    configuration = FeignConfig.class
 )
 public interface ProductFeignClient {
 

--- a/order-service/src/main/java/com/musinsam/orderservice/infrastructure/config/FeignClientConfig.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/infrastructure/config/FeignClientConfig.java
@@ -1,0 +1,13 @@
+package com.musinsam.orderservice.infrastructure.config;
+
+import com.musinsam.orderservice.infrastructure.client.ProductFeignClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(clients = {
+    ProductFeignClient.class
+})
+public class FeignClientConfig {
+
+}

--- a/order-service/src/main/java/com/musinsam/orderservice/infrastructure/persistence/order/OrderJpaRepository.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/infrastructure/persistence/order/OrderJpaRepository.java
@@ -28,5 +28,5 @@ public interface OrderJpaRepository extends
   @Override
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("SELECT o FROM OrderEntity o LEFT JOIN FETCH o.orderItems WHERE o.id = :orderId")
-  Optional<OrderEntity> findByIdWithOrderItemsForUpdate(@Param("id") UUID orderId);
+  Optional<OrderEntity> findByIdWithOrderItemsForUpdate(@Param("orderId") UUID orderId);
 }

--- a/order-service/src/main/java/com/musinsam/orderservice/infrastructure/persistence/order/OrderJpaRepository.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/infrastructure/persistence/order/OrderJpaRepository.java
@@ -2,9 +2,11 @@ package com.musinsam.orderservice.infrastructure.persistence.order;
 
 import com.musinsam.orderservice.domain.order.entity.OrderEntity;
 import com.musinsam.orderservice.domain.order.repository.OrderRepository;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.repository.query.Param;
@@ -22,4 +24,9 @@ public interface OrderJpaRepository extends
   @Override
   @Query("SELECT o FROM OrderEntity o LEFT JOIN FETCH o.orderItems WHERE o.id = :orderId")
   Optional<OrderEntity> findByIdWithOrderItems(@Param("orderId") UUID orderId);
+
+  @Override
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT o FROM OrderEntity o LEFT JOIN FETCH o.orderItems WHERE o.id = :orderId")
+  Optional<OrderEntity> findByIdWithOrderItemsForUpdate(@Param("id") UUID orderId);
 }

--- a/order-service/src/main/java/com/musinsam/orderservice/presentation/advice/OrderExceptionHandler.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/presentation/advice/OrderExceptionHandler.java
@@ -11,6 +11,7 @@ import com.musinsam.orderservice.domain.order.exception.OrderException;
 import com.musinsam.orderservice.domain.order.exception.OrderNotFoundException;
 import com.musinsam.orderservice.domain.order.exception.OrderProductException;
 import com.musinsam.orderservice.domain.order.exception.OrderStatusException;
+import com.musinsam.orderservice.domain.order.exception.OrderStockRestoreException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -91,6 +92,12 @@ public class OrderExceptionHandler {
   @ExceptionHandler(OrderControlException.class)
   public ResponseEntity<ErrorResponse> handleOrderControlException(
       OrderControlException ex, HttpServletRequest request) {
+    return createOrderBaseException(ex, request, false);
+  }
+
+  @ExceptionHandler(OrderStockRestoreException.class)
+  public ResponseEntity<ErrorResponse> handleOrderStoreRestoreException(
+      OrderStockRestoreException ex, HttpServletRequest request) {
     return createOrderBaseException(ex, request, false);
   }
 

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -33,6 +33,13 @@ eureka:
     service-url:
       defaultZone: http://localhost:8761/eureka/
 
+resilience4j:
+  retry:
+    instances:
+      product-service:
+        max-attempts: 3
+        wait-duration: 500ms
+
 springdoc:
   swagger-ui:
     enabled: true

--- a/order-service/src/test/java/http/order.http
+++ b/order-service/src/test/java/http/order.http
@@ -135,7 +135,7 @@ X-User-Role: {{userRole}}
       },
       {
         "id": "d8fe1ffd-e525-4ad6-973a-ad07acd039c8",
-        "productId": "3f6164db-5907-4cf0-afe4-c219527516ae",
+        "productId": "3f6164db-5907-4cf0-afe4-c219527516a0",
         "productName": "New Sample Product",
         "quantity": 1,
         "price": 50000

--- a/payment-service/src/main/java/com/musinsam/paymentservice/infrastructure/client/OrderFeignClient.java
+++ b/payment-service/src/main/java/com/musinsam/paymentservice/infrastructure/client/OrderFeignClient.java
@@ -13,8 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(
     name = "order-service",
-    configuration = FeignConfig.class,
-    url = "http://localhost:12001"
+    configuration = FeignConfig.class
 )
 public interface OrderFeignClient {
 

--- a/product-service/src/main/java/com/musinsam/productservice/presentation/controller/ProductInternalControllerApiV1.java
+++ b/product-service/src/main/java/com/musinsam/productservice/presentation/controller/ProductInternalControllerApiV1.java
@@ -4,7 +4,6 @@ import com.musinsam.productservice.application.service.ProductServiceApiV1;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,7 +30,7 @@ public class ProductInternalControllerApiV1 {
   /**
    * 재고 복구
    */
-  @PatchMapping("/stock/restore")
+  @PutMapping("/stock/restore")
   public ResponseEntity<Void> updateProductStock(
       @RequestParam UUID productId,
       @RequestParam Integer quantity


### PR DESCRIPTION
## #️⃣연관된 이슈

- #227

## 📝작업 내용

> 주문/주문 취소 동기식 처리
> resilience4j 적용
> 테스트 용 코드 일부 수정


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 주문 생성, 수정, 취소 시 상품 재고를 외부 상품 서비스와 연동하여 관리하도록 개선되었습니다.
  - 주문 서비스에서 상품 재고 감소 및 복원을 위한 Feign 클라이언트가 추가되었습니다.
  - 재고 복원 실패 시 새로운 예외 처리 및 에러 코드가 도입되었습니다.
  - 주문 저장소에 주문과 주문 항목을 조회하며 잠금 기능을 적용하는 메서드가 추가되었습니다.
  - 주문 서비스에 Resilience4j 재시도 설정이 추가되었습니다.
  - 주문 예외 처리기에서 재고 복원 예외를 처리하도록 확장되었습니다.

- **버그 수정**
  - 상품 서비스의 재고 복원 API가 PATCH에서 PUT 메서드로 변경되었습니다.

- **성능 테스트**
  - 주문 API 부하 테스트 시나리오가 동시 사용자 기반으로 변경되고, 응답 시간 검증이 제거되었습니다.

- **문서/테스트**
  - 주문 수정 테스트 데이터의 상품 ID가 일부 변경되었습니다.

- **환경설정**
  - 주문 서비스에 Resilience4j, Spring AOP, OpenFeign 관련 라이브러리가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->