### PR TITLE
[Order] 주문 서비스 레이어 리팩토링

### DIFF
--- a/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderServiceApiV1.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderServiceApiV1.java
@@ -86,13 +86,13 @@ public class OrderServiceApiV1 {
 
     orderStockMangerV1.restoreProductStock(orderEntity);
 
+    requestDto.getOrder().updateEntity(orderEntity);
+
     boolean stockAvailable = orderStockMangerV1.checkAndReduceStock(orderEntity);
 
     if (!stockAvailable) {
       throw OrderException.from(OrderErrorCode.ORDER_PRODUCT_NOT_AVAILABLE);
     }
-
-    requestDto.getOrder().updateEntity(orderEntity);
 
     return ResOrderPutDtoApiV1.of(orderEntity);
   }

--- a/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderServiceApiV1.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderServiceApiV1.java
@@ -1,7 +1,5 @@
 package com.musinsam.orderservice.application.service;
 
-import com.musinsam.common.exception.CommonErrorCode;
-import com.musinsam.common.exception.CustomException;
 import com.musinsam.orderservice.application.dto.request.ReqOrderPostCancelDtoApiV1;
 import com.musinsam.orderservice.application.dto.request.ReqOrderPostDtoApiV1;
 import com.musinsam.orderservice.application.dto.request.ReqOrderPutDtoApiV1;
@@ -13,22 +11,16 @@ import com.musinsam.orderservice.application.dto.response.ResOrderPutDtoApiV1;
 import com.musinsam.orderservice.domain.order.entity.OrderEntity;
 import com.musinsam.orderservice.domain.order.entity.OrderItemEntity;
 import com.musinsam.orderservice.domain.order.exception.OrderException;
-import com.musinsam.orderservice.domain.order.exception.OrderStockRestoreException;
 import com.musinsam.orderservice.domain.order.repository.OrderRepository;
 import com.musinsam.orderservice.domain.order.vo.OrderErrorCode;
 import com.musinsam.orderservice.domain.order.vo.OrderStatus;
-import com.musinsam.orderservice.infrastructure.client.ProductFeignClient;
 import com.querydsl.core.types.Predicate;
-import io.github.resilience4j.retry.annotation.Retry;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,19 +30,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderServiceApiV1 {
 
   private final OrderRepository orderRepository;
-  private final ProductFeignClient productFeignClient;
+  private final OrderValidatorV1 orderValidator;
+  private final OrderStockMangerV1 orderStockMangerV1;
 
   @Transactional
   public ResOrderPostDtoApiV1 createOrder(ReqOrderPostDtoApiV1 requestDto, Long userId) {
 
     OrderEntity orderEntity = requestDto.getOrder().toEntityWith(userId);
 
-    validateOrderOwner(orderEntity, userId);
-    validateOrderStatus(orderEntity);
+    orderValidator.validateOrderOwner(orderEntity, userId);
+    orderValidator.validateOrderStatus(orderEntity);
 
     OrderEntity savedOrder = orderRepository.save(orderEntity);
 
-    boolean stockAvailable = checkAndReduceStock(orderEntity);
+    boolean stockAvailable = orderStockMangerV1.checkAndReduceStock(orderEntity);
 
     if (!stockAvailable) {
       throw OrderException.from(OrderErrorCode.ORDER_PRODUCT_NOT_AVAILABLE);
@@ -65,7 +58,7 @@ public class OrderServiceApiV1 {
     OrderEntity orderEntity = orderRepository.findByIdWithOrderItems(orderId)
         .orElseThrow(() -> OrderException.from(OrderErrorCode.ORDER_NOT_FOUND));
 
-    validateOrderOwner(orderEntity, userId);
+    orderValidator.validateOrderOwner(orderEntity, userId);
 
     return ResOrderGetByIdDtoApiV1.of(orderEntity);
   }
@@ -88,12 +81,12 @@ public class OrderServiceApiV1 {
     OrderEntity orderEntity = orderRepository.findByIdWithOrderItemsForUpdate(orderId)
         .orElseThrow(() -> OrderException.from(OrderErrorCode.ORDER_NOT_FOUND));
 
-    validateOrderOwner(orderEntity, userId);
-    validateOrderStatus(orderEntity);
+    orderValidator.validateOrderOwner(orderEntity, userId);
+    orderValidator.validateOrderStatus(orderEntity);
 
-    restoreProductStock(orderEntity);
+    orderStockMangerV1.restoreProductStock(orderEntity);
 
-    boolean stockAvailable = checkAndReduceStock(orderEntity);
+    boolean stockAvailable = orderStockMangerV1.checkAndReduceStock(orderEntity);
 
     if (!stockAvailable) {
       throw OrderException.from(OrderErrorCode.ORDER_PRODUCT_NOT_AVAILABLE);
@@ -111,16 +104,16 @@ public class OrderServiceApiV1 {
     OrderEntity orderEntity = orderRepository.findByIdWithOrderItems(orderId)
         .orElseThrow(() -> OrderException.from(OrderErrorCode.ORDER_NOT_FOUND));
 
-    validateOrderOwner(orderEntity, userId);
+    orderValidator.validateOrderOwner(orderEntity, userId);
 
-    validateCancellableStatus(orderEntity);
+    orderValidator.validateCancellableStatus(orderEntity);
 
     orderEntity.cancel(
         requestDto.getOrder().getCancelType(),
         requestDto.getOrder().getCancelReason()
     );
 
-    restoreProductStock(orderEntity);
+    orderStockMangerV1.restoreProductStock(orderEntity);
 
     return ResOrderPostCancelDtoApiV1.of(orderEntity);
   }
@@ -130,8 +123,8 @@ public class OrderServiceApiV1 {
     OrderEntity orderEntity = orderRepository.findByIdWithOrderItems(orderId)
         .orElseThrow(() -> OrderException.from(OrderErrorCode.ORDER_NOT_FOUND));
 
-    validateOrderOwner(orderEntity, userId);
-    validateDeletableStatus(orderEntity);
+    orderValidator.validateOrderOwner(orderEntity, userId);
+    orderValidator.validateDeletableStatus(orderEntity);
 
     ZoneId zoneId = ZoneId.systemDefault();
 
@@ -140,116 +133,6 @@ public class OrderServiceApiV1 {
 
     for (OrderItemEntity item : orderEntity.getOrderItems()) {
       item.softDelete(userId, zoneId);
-    }
-  }
-
-  private boolean checkAndReduceStock(OrderEntity orderEntity) {
-
-    log.debug("주문 상품 재고 확인 및 차감 시작: 주문 ID={}", orderEntity.getId());
-    List<OrderItemEntity> processedItems = new ArrayList<>();
-
-    for (OrderItemEntity item : orderEntity.getOrderItems()) {
-      log.debug("상품 재고 차감 시도: 상품 ID={}, 수량={}", item.getProductId(), item.getQuantity());
-      boolean success = attemptStockReduction(item);
-
-      if (!success) {
-        log.debug("상품 재고 차감 실패, 롤백 시작: 상품 ID={}", item.getProductId());
-        rollbackStockReduction(processedItems);
-        return false;
-      }
-
-      processedItems.add(item);
-    }
-    log.debug("모든 상품 재고 차감 성공: 주문 ID={}", orderEntity.getId());
-    return true;
-  }
-
-  @Retry(name = "product-service", fallbackMethod = "stockReductionFallback")
-  private boolean attemptStockReduction(OrderItemEntity item) {
-    ResponseEntity<Boolean> response = productFeignClient.checkAndReduceStock(
-        item.getProductId(), item.getQuantity());
-
-    if (response.getStatusCode().is2xxSuccessful()
-        && Boolean.TRUE.equals(response.getBody())) {
-      return true;
-    }
-
-    return false;
-  }
-
-  private boolean stockReductionFallback(OrderItemEntity item, Exception e) {
-    log.debug("상품 재고 차감 실패: productId={}, quantity={}, 오류={}",
-        item.getProductId(), item.getQuantity(), e.getMessage());
-    return false;
-
-  }
-
-  @Retry(name = "product-service", fallbackMethod = "restoreProductStockFallback")
-  private void rollbackStockReduction(List<OrderItemEntity> processedItems) {
-    if (processedItems.isEmpty()) {
-      return;
-    }
-
-    for (OrderItemEntity item : processedItems) {
-      ResponseEntity<Void> response = productFeignClient.restoreStock(item.getProductId(),
-          item.getQuantity());
-
-      if (!response.getStatusCode().is2xxSuccessful()) {
-        log.debug("재고 롤백 요청 실패: 상품 ID={}, 응답코드={}", item.getProductId(), response.getStatusCode());
-        throw new OrderStockRestoreException();
-      }
-    }
-
-    log.debug("모든 상품 재고 롤백 완료: 처리된 상품 수={}", processedItems.size());
-  }
-
-  private void restoreProductStock(OrderEntity orderEntity) {
-    for (OrderItemEntity item : orderEntity.getOrderItems()) {
-      ResponseEntity<Void> response = productFeignClient.restoreStock(item.getProductId(),
-          item.getQuantity());
-
-      if (!response.getStatusCode().is2xxSuccessful()) {
-        throw new OrderStockRestoreException();
-      }
-    }
-  }
-
-  private void restoreProductStockFallback(OrderEntity orderEntity, Exception e) {
-    log.debug("주문 취소 시 재고 복원 실패: 주문 ID={}, 오류={}",
-        orderEntity.getId(), e.getMessage());
-
-    throw new OrderStockRestoreException();
-  }
-
-  private void validateDeletableStatus(OrderEntity orderEntity) {
-    List<OrderStatus> deletableStatuses = List.of(
-        OrderStatus.CANCELED
-    );
-
-    if (!deletableStatuses.contains(orderEntity.getOrderStatus())) {
-      throw OrderException.from(OrderErrorCode.ORDER_CANNOT_BE_DELETED);
-    }
-  }
-
-  private void validateCancellableStatus(OrderEntity orderEntity) {
-    List<OrderStatus> cancelableStatuses = List.of(
-        OrderStatus.PENDING
-    );
-
-    if (!cancelableStatuses.contains(orderEntity.getOrderStatus())) {
-      throw OrderException.from(OrderErrorCode.ORDER_CANNOT_BE_CANCELED);
-    }
-  }
-
-  private void validateOrderStatus(OrderEntity orderEntity) {
-    if (!orderEntity.getOrderStatus().equals(OrderStatus.PENDING)) {
-      throw OrderException.from(OrderErrorCode.ORDER_INVALID_STATUS);
-    }
-  }
-
-  private void validateOrderOwner(OrderEntity orderEntity, Long userId) {
-    if (!orderEntity.getUserId().equals(userId)) {
-      throw CustomException.from(CommonErrorCode.FORBIDDEN);
     }
   }
 }

--- a/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderServiceApiV1.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderServiceApiV1.java
@@ -31,7 +31,7 @@ public class OrderServiceApiV1 {
 
   private final OrderRepository orderRepository;
   private final OrderValidatorV1 orderValidatorV1;
-  private final OrderStockMangerV1 orderStockMangerV1;
+  private final OrderStockManagerV1 orderStockManagerV1;
 
   @Transactional
   public ResOrderPostDtoApiV1 createOrder(ReqOrderPostDtoApiV1 requestDto, Long userId) {
@@ -43,7 +43,7 @@ public class OrderServiceApiV1 {
 
     OrderEntity savedOrder = orderRepository.save(orderEntity);
 
-    boolean stockAvailable = orderStockMangerV1.checkAndReduceStock(orderEntity);
+    boolean stockAvailable = orderStockManagerV1.checkAndReduceStock(orderEntity);
 
     if (!stockAvailable) {
       throw OrderException.from(OrderErrorCode.ORDER_PRODUCT_NOT_AVAILABLE);
@@ -84,11 +84,11 @@ public class OrderServiceApiV1 {
     orderValidatorV1.validateOrderOwner(orderEntity, userId);
     orderValidatorV1.validateOrderStatus(orderEntity);
 
-    orderStockMangerV1.restoreProductStock(orderEntity);
+    orderStockManagerV1.restoreProductStock(orderEntity);
 
     requestDto.getOrder().updateEntity(orderEntity);
 
-    boolean stockAvailable = orderStockMangerV1.checkAndReduceStock(orderEntity);
+    boolean stockAvailable = orderStockManagerV1.checkAndReduceStock(orderEntity);
 
     if (!stockAvailable) {
       throw OrderException.from(OrderErrorCode.ORDER_PRODUCT_NOT_AVAILABLE);
@@ -113,7 +113,7 @@ public class OrderServiceApiV1 {
         requestDto.getOrder().getCancelReason()
     );
 
-    orderStockMangerV1.restoreProductStock(orderEntity);
+    orderStockManagerV1.restoreProductStock(orderEntity);
 
     return ResOrderPostCancelDtoApiV1.of(orderEntity);
   }

--- a/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderServiceApiV1.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderServiceApiV1.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderServiceApiV1 {
 
   private final OrderRepository orderRepository;
-  private final OrderValidatorV1 orderValidator;
+  private final OrderValidatorV1 orderValidatorV1;
   private final OrderStockMangerV1 orderStockMangerV1;
 
   @Transactional
@@ -38,8 +38,8 @@ public class OrderServiceApiV1 {
 
     OrderEntity orderEntity = requestDto.getOrder().toEntityWith(userId);
 
-    orderValidator.validateOrderOwner(orderEntity, userId);
-    orderValidator.validateOrderStatus(orderEntity);
+    orderValidatorV1.validateOrderOwner(orderEntity, userId);
+    orderValidatorV1.validateOrderStatus(orderEntity);
 
     OrderEntity savedOrder = orderRepository.save(orderEntity);
 
@@ -58,7 +58,7 @@ public class OrderServiceApiV1 {
     OrderEntity orderEntity = orderRepository.findByIdWithOrderItems(orderId)
         .orElseThrow(() -> OrderException.from(OrderErrorCode.ORDER_NOT_FOUND));
 
-    orderValidator.validateOrderOwner(orderEntity, userId);
+    orderValidatorV1.validateOrderOwner(orderEntity, userId);
 
     return ResOrderGetByIdDtoApiV1.of(orderEntity);
   }
@@ -81,8 +81,8 @@ public class OrderServiceApiV1 {
     OrderEntity orderEntity = orderRepository.findByIdWithOrderItemsForUpdate(orderId)
         .orElseThrow(() -> OrderException.from(OrderErrorCode.ORDER_NOT_FOUND));
 
-    orderValidator.validateOrderOwner(orderEntity, userId);
-    orderValidator.validateOrderStatus(orderEntity);
+    orderValidatorV1.validateOrderOwner(orderEntity, userId);
+    orderValidatorV1.validateOrderStatus(orderEntity);
 
     orderStockMangerV1.restoreProductStock(orderEntity);
 
@@ -104,9 +104,9 @@ public class OrderServiceApiV1 {
     OrderEntity orderEntity = orderRepository.findByIdWithOrderItems(orderId)
         .orElseThrow(() -> OrderException.from(OrderErrorCode.ORDER_NOT_FOUND));
 
-    orderValidator.validateOrderOwner(orderEntity, userId);
+    orderValidatorV1.validateOrderOwner(orderEntity, userId);
 
-    orderValidator.validateCancellableStatus(orderEntity);
+    orderValidatorV1.validateCancellableStatus(orderEntity);
 
     orderEntity.cancel(
         requestDto.getOrder().getCancelType(),
@@ -123,8 +123,8 @@ public class OrderServiceApiV1 {
     OrderEntity orderEntity = orderRepository.findByIdWithOrderItems(orderId)
         .orElseThrow(() -> OrderException.from(OrderErrorCode.ORDER_NOT_FOUND));
 
-    orderValidator.validateOrderOwner(orderEntity, userId);
-    orderValidator.validateDeletableStatus(orderEntity);
+    orderValidatorV1.validateOrderOwner(orderEntity, userId);
+    orderValidatorV1.validateDeletableStatus(orderEntity);
 
     ZoneId zoneId = ZoneId.systemDefault();
 

--- a/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderStockManagerV1.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderStockManagerV1.java
@@ -19,6 +19,12 @@ public class OrderStockManagerV1 {
 
   private final ProductFeignClient productFeignClient;
 
+  /**
+   * 주문 항목의 재고를 확인하고 차감. 재고 차감에 실패할 경우 이미 처리된 항목들을 롤백한다.
+   *
+   * @param orderEntity 재고를 차감할 주문 엔티티
+   * @return 모든 상품의 재고 차감 성공 시 true, 실패 시 false
+   */
   public boolean checkAndReduceStock(OrderEntity orderEntity) {
 
     log.debug("주문 상품 재고 확인 및 차감 시작: 주문 ID={}", orderEntity.getId());
@@ -40,6 +46,12 @@ public class OrderStockManagerV1 {
     return true;
   }
 
+  /**
+   * 단일 주문 항목에 대한 재고 차감. Feign Client를 통해 상품 서비스에 재고 차감을 요청한다.
+   *
+   * @param item 재고를 차감할 OrderItem 엔티티
+   * @return 재고 차감 성공 시 true, 실패 시 false
+   */
   @Retry(name = "product-service", fallbackMethod = "stockReductionFallback")
   public boolean attemptStockReduction(OrderItemEntity item) {
     ResponseEntity<Boolean> response = productFeignClient.checkAndReduceStock(
@@ -60,6 +72,11 @@ public class OrderStockManagerV1 {
 
   }
 
+  /**
+   * 이미 처리된 주문 항목들의 재고를 원래대로 복원한다. Feign Client를 통해 상품 복구를 요청한다.
+   *
+   * @param processedItems 재고를 복원할 주문 항목 목록
+   */
   @Retry(name = "product-service", fallbackMethod = "rollbackStockReductionFallback")
   public void rollbackStockReduction(List<OrderItemEntity> processedItems) {
     if (processedItems.isEmpty()) {
@@ -83,6 +100,11 @@ public class OrderStockManagerV1 {
     log.error("재고 롤백 과정에서 복구 오류 발생: {}", e.getMessage());
   }
 
+  /**
+   * 주문 취소 또는 수정 시 모든 주문 항목의 재고를 복원한다. Feign Client를 통해 요청 주문의 상품들의 재고를 복원한다.
+   *
+   * @param orderEntity 재고를 복원할 주문 엔티티
+   */
   @Retry(name = "product-service", fallbackMethod = "restoreProductStockFallback")
   public void restoreProductStock(OrderEntity orderEntity) {
     for (OrderItemEntity item : orderEntity.getOrderItems()) {

--- a/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderStockManagerV1.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderStockManagerV1.java
@@ -79,6 +79,7 @@ public class OrderStockManagerV1 {
     log.debug("모든 상품 재고 롤백 완료: 처리된 상품 수={}", processedItems.size());
   }
 
+  @Retry(name = "product-service", fallbackMethod = "restoreProductStockFallback")
   public void restoreProductStock(OrderEntity orderEntity) {
     for (OrderItemEntity item : orderEntity.getOrderItems()) {
       ResponseEntity<Void> response = productFeignClient.restoreStock(item.getProductId(),

--- a/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderStockManagerV1.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderStockManagerV1.java
@@ -106,6 +106,7 @@ public class OrderStockManagerV1 {
 
   public void rollbackStockReductionFallback(List<OrderItemEntity> processedItems, Exception e) {
     log.error("재고 롤백 과정에서 복구 오류 발생: {}", e.getMessage());
+    throw new OrderStockRestoreException();
   }
 
   /**

--- a/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderStockManagerV1.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderStockManagerV1.java
@@ -60,7 +60,7 @@ public class OrderStockManagerV1 {
 
   }
 
-  @Retry(name = "product-service", fallbackMethod = "restoreProductStockFallback")
+  @Retry(name = "product-service", fallbackMethod = "rollbackStockReductionFallback")
   public void rollbackStockReduction(List<OrderItemEntity> processedItems) {
     if (processedItems.isEmpty()) {
       return;
@@ -77,6 +77,10 @@ public class OrderStockManagerV1 {
     }
 
     log.debug("모든 상품 재고 롤백 완료: 처리된 상품 수={}", processedItems.size());
+  }
+
+  public void rollbackStockReductionFallback(List<OrderItemEntity> processedItems, Exception e) {
+    log.error("재고 롤백 과정에서 복구 오류 발생: {}", e.getMessage());
   }
 
   @Retry(name = "product-service", fallbackMethod = "restoreProductStockFallback")

--- a/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderStockManagerV1.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderStockManagerV1.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class OrderStockMangerV1 {
+public class OrderStockManagerV1 {
 
   private final ProductFeignClient productFeignClient;
 

--- a/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderStockMangerV1.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderStockMangerV1.java
@@ -1,0 +1,99 @@
+package com.musinsam.orderservice.application.service;
+
+import com.musinsam.orderservice.domain.order.entity.OrderEntity;
+import com.musinsam.orderservice.domain.order.entity.OrderItemEntity;
+import com.musinsam.orderservice.domain.order.exception.OrderStockRestoreException;
+import com.musinsam.orderservice.infrastructure.client.ProductFeignClient;
+import io.github.resilience4j.retry.annotation.Retry;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderStockMangerV1 {
+
+  private final ProductFeignClient productFeignClient;
+
+  public boolean checkAndReduceStock(OrderEntity orderEntity) {
+
+    log.debug("주문 상품 재고 확인 및 차감 시작: 주문 ID={}", orderEntity.getId());
+    List<OrderItemEntity> processedItems = new ArrayList<>();
+
+    for (OrderItemEntity item : orderEntity.getOrderItems()) {
+      log.debug("상품 재고 차감 시도: 상품 ID={}, 수량={}", item.getProductId(), item.getQuantity());
+      boolean success = attemptStockReduction(item);
+
+      if (!success) {
+        log.debug("상품 재고 차감 실패, 롤백 시작: 상품 ID={}", item.getProductId());
+        rollbackStockReduction(processedItems);
+        return false;
+      }
+
+      processedItems.add(item);
+    }
+    log.debug("모든 상품 재고 차감 성공: 주문 ID={}", orderEntity.getId());
+    return true;
+  }
+
+  @Retry(name = "product-service", fallbackMethod = "stockReductionFallback")
+  public boolean attemptStockReduction(OrderItemEntity item) {
+    ResponseEntity<Boolean> response = productFeignClient.checkAndReduceStock(
+        item.getProductId(), item.getQuantity());
+
+    if (response.getStatusCode().is2xxSuccessful()
+        && Boolean.TRUE.equals(response.getBody())) {
+      return true;
+    }
+
+    return false;
+  }
+
+  public boolean stockReductionFallback(OrderItemEntity item, Exception e) {
+    log.debug("상품 재고 차감 실패: productId={}, quantity={}, 오류={}",
+        item.getProductId(), item.getQuantity(), e.getMessage());
+    return false;
+
+  }
+
+  @Retry(name = "product-service", fallbackMethod = "restoreProductStockFallback")
+  public void rollbackStockReduction(List<OrderItemEntity> processedItems) {
+    if (processedItems.isEmpty()) {
+      return;
+    }
+
+    for (OrderItemEntity item : processedItems) {
+      ResponseEntity<Void> response = productFeignClient.restoreStock(item.getProductId(),
+          item.getQuantity());
+
+      if (!response.getStatusCode().is2xxSuccessful()) {
+        log.debug("재고 롤백 요청 실패: 상품 ID={}, 응답코드={}", item.getProductId(), response.getStatusCode());
+        throw new OrderStockRestoreException();
+      }
+    }
+
+    log.debug("모든 상품 재고 롤백 완료: 처리된 상품 수={}", processedItems.size());
+  }
+
+  public void restoreProductStock(OrderEntity orderEntity) {
+    for (OrderItemEntity item : orderEntity.getOrderItems()) {
+      ResponseEntity<Void> response = productFeignClient.restoreStock(item.getProductId(),
+          item.getQuantity());
+
+      if (!response.getStatusCode().is2xxSuccessful()) {
+        throw new OrderStockRestoreException();
+      }
+    }
+  }
+
+  public void restoreProductStockFallback(OrderEntity orderEntity, Exception e) {
+    log.debug("주문 취소 시 재고 복원 실패: 주문 ID={}, 오류={}",
+        orderEntity.getId(), e.getMessage());
+
+    throw new OrderStockRestoreException();
+  }
+}

--- a/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderValidatorV1.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/service/OrderValidatorV1.java
@@ -1,0 +1,48 @@
+package com.musinsam.orderservice.application.service;
+
+import com.musinsam.common.exception.CommonErrorCode;
+import com.musinsam.common.exception.CustomException;
+import com.musinsam.orderservice.domain.order.entity.OrderEntity;
+import com.musinsam.orderservice.domain.order.exception.OrderException;
+import com.musinsam.orderservice.domain.order.vo.OrderErrorCode;
+import com.musinsam.orderservice.domain.order.vo.OrderStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderValidatorV1 {
+
+  public void validateDeletableStatus(OrderEntity orderEntity) {
+    List<OrderStatus> deletableStatuses = List.of(
+        OrderStatus.CANCELED
+    );
+
+    if (!deletableStatuses.contains(orderEntity.getOrderStatus())) {
+      throw OrderException.from(OrderErrorCode.ORDER_CANNOT_BE_DELETED);
+    }
+  }
+
+  public void validateCancellableStatus(OrderEntity orderEntity) {
+    List<OrderStatus> cancelableStatuses = List.of(
+        OrderStatus.PENDING
+    );
+
+    if (!cancelableStatuses.contains(orderEntity.getOrderStatus())) {
+      throw OrderException.from(OrderErrorCode.ORDER_CANNOT_BE_CANCELED);
+    }
+  }
+
+  public void validateOrderStatus(OrderEntity orderEntity) {
+    if (!orderEntity.getOrderStatus().equals(OrderStatus.PENDING)) {
+      throw OrderException.from(OrderErrorCode.ORDER_INVALID_STATUS);
+    }
+  }
+
+  public void validateOrderOwner(OrderEntity orderEntity, Long userId) {
+    if (!orderEntity.getUserId().equals(userId)) {
+      throw CustomException.from(CommonErrorCode.FORBIDDEN);
+    }
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #239 

## 📝작업 내용

> 서비스 레이어가 비지니스 로직에만 집중하도록 변경


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 주문 상태 및 소유자 검증을 전담하는 별도의 검증 컴포넌트가 도입되었습니다.
    - 주문 관련 재고 확인 및 복구 작업을 전담하는 별도의 재고 관리 컴포넌트가 도입되었습니다.

- **리팩터**
    - 주문 처리 시 검증 및 재고 관리 로직이 서비스 내부에서 분리되어, 각 역할별 컴포넌트로 위임되었습니다.
    - API의 동작 방식과 응답에는 변화가 없으며, 사용자 경험은 동일하게 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->