### PR TITLE
[Order] 분산 락을 구현 하기 위한 ApiV2 작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-read me
+![image](https://github.com/user-attachments/assets/7f947ca1-88e6-44a6-9b4f-d61e3ad2af76)

--- a/eureka-gateway/src/main/resources/application.yml
+++ b/eureka-gateway/src/main/resources/application.yml
@@ -128,7 +128,7 @@ spring:
         - id: order-service
           uri: lb://ORDER-SERVICE
           predicates:
-            - Path=/v1/orders/**
+            - Path=/v1/orders/**, /v2/orders/**
 
         - id: internal-payment-service
           uri: lb://PAYMENT-SERVICE

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -19,6 +19,16 @@ services:
     networks:
       - laboratory-network
 
+  redis-order:
+    image: redis:latest
+    container_name: redis-order
+    ports:
+      - "6381:6379"
+    volumes:
+      - ./redis-order-config:/usr/local/etc/redis
+    networks:
+      - laboratory-network
+
   postgres:
     image: postgres:latest
     container_name: postgres-db
@@ -238,7 +248,27 @@ services:
       - "test"
     volumes:
       - ./k6-scripts:/k6-scripts
-    command: run -o experimental-prometheus-rw /k6-scripts/order-api-stress-test.js
+    command: run --tag testid=order-stress-test -o experimental-prometheus-rw /k6-scripts/order-api-stress-test.js
+    env_file:
+      - ../.env
+    environment:
+      - K6_PROMETHEUS_RW_SERVER_URL=http://prometheus:9090/api/v1/write
+      - K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM=true
+      - TEST_ID=1
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      - prometheus
+    networks:
+      - laboratory-network
+
+  k6-lock-test:
+    image: grafana/k6
+    profiles:
+      - "test"
+    volumes:
+      - ./k6-scripts:/k6-scripts
+    command: run --tag testid=order-lock-test -o experimental-prometheus-rw /k6-scripts/order-distributed-lock-test.js
     env_file:
       - ../.env
     environment:

--- a/infrastructure/k6-scripts/order-distributed-lock-test.js
+++ b/infrastructure/k6-scripts/order-distributed-lock-test.js
@@ -1,26 +1,22 @@
 import http from 'k6/http';
-import {check} from 'k6';
+import {check, sleep} from 'k6';
 
 const token = __ENV.TEST_AUTH_TOKEN;
 const userId = __ENV.TEST_USER_ID;
 const userRole = __ENV.TEST_USER_ROLE;
 
 export const options = {
-  stages: [
-    {duration: '10s', target: 100},
-    {duration: '10s', target: 200},
-    {duration: '10s', target: 300},
-    {duration: '10s', target: 400},
-    {duration: '10s', target: 500},
-    {duration: '10s', target: 0},
-  ],
-  thresholds: {
-    http_req_duration: ['p(95)<1000'],
-  },
+  scenarios: {
+    concurrent_requests: {
+      executor: 'constant-vus',
+      vus: 100,
+      duration: '10s'
+    },
+  }
 };
 
 export default function () {
-  const url = 'http://host.docker.internal:10000/v1/orders';
+  const url = 'http://host.docker.internal:10000/v2/orders';
 
   const payload = JSON.stringify({
     order: {
@@ -39,14 +35,14 @@ export default function () {
         },
       ],
       shippingInfo: {
-        receiverName: 'John Doe',
+        receiverName: 'Lock Test User',
         receiverPhone: '010-1234-5678',
         zipCode: '12345',
-        address: 'Shipping Address',
-        addressDetail: 'Shipping Address Detail',
+        address: 'Test Address',
+        addressDetail: 'Test Address Detail',
       },
-      request: 'Request Example',
-      orderName: 'Order Name Sample',
+      request: `분산락 테스트 주문 - ${__VU} 번 사용자`,
+      orderName: `분산락 테스트 주문 - ${__VU} 번 사용자`,
       couponId: 'e676a7e8-9ab4-4452-a41c-351b69bba2d1',
       totalAmount: 500000,
       discountAmount: 33333,
@@ -58,15 +54,15 @@ export default function () {
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
-      'X-User-Id': userId,
-      'X-User-Role': userRole
+      'X-USER-ID': userId,
+      'X-USER-ROLE': userRole
     },
   };
 
   const response = http.post(url, payload, params);
 
   check(response, {
-    'status is 200': (r) => r.status === 200
+    'status is 200': (r) => r.status === 200,
   });
 
   if (response.status === 200) {
@@ -75,4 +71,6 @@ export default function () {
     console.log(
         `VU ${__VU}: 주문 실패 - 상태 코드: ${response.status}, 메시지: ${response.body}`);
   }
+
+  sleep(Math.random());
 }

--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -26,6 +26,11 @@ ext {
 dependencies {
     implementation project(':common')
 
+    // redis dependencies
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.23.5'
+    implementation 'org.redisson:redisson:3.23.5'
+
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
     implementation "org.springframework.boot:spring-boot-starter-aop"
 

--- a/order-service/src/main/java/com/musinsam/orderservice/application/dto/request/v2/ReqOrderPostCancelDtoApiV2.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/dto/request/v2/ReqOrderPostCancelDtoApiV2.java
@@ -1,6 +1,5 @@
 package com.musinsam.orderservice.application.dto.request.v2;
 
-import com.musinsam.orderservice.application.dto.request.ReqOrderPostCancelDtoApiV1;
 import com.musinsam.orderservice.domain.order.vo.OrderCancelType;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -17,7 +16,7 @@ public class ReqOrderPostCancelDtoApiV2 {
 
   @Valid
   @NotNull(message = "주문 정보가 존재하지 않습니다.")
-  private ReqOrderPostCancelDtoApiV1.Order order;
+  private Order order;
 
   @Getter
   @Builder

--- a/order-service/src/main/java/com/musinsam/orderservice/application/dto/request/v2/ReqOrderPostCancelDtoApiV2.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/dto/request/v2/ReqOrderPostCancelDtoApiV2.java
@@ -1,0 +1,31 @@
+package com.musinsam.orderservice.application.dto.request.v2;
+
+import com.musinsam.orderservice.application.dto.request.ReqOrderPostCancelDtoApiV1;
+import com.musinsam.orderservice.domain.order.vo.OrderCancelType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReqOrderPostCancelDtoApiV2 {
+
+  @Valid
+  @NotNull(message = "주문 정보가 존재하지 않습니다.")
+  private ReqOrderPostCancelDtoApiV1.Order order;
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Order {
+
+    private String cancelReason;
+    private OrderCancelType cancelType;
+  }
+}

--- a/order-service/src/main/java/com/musinsam/orderservice/application/dto/request/v2/ReqOrderPostDtoApiV2.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/dto/request/v2/ReqOrderPostDtoApiV2.java
@@ -1,0 +1,103 @@
+package com.musinsam.orderservice.application.dto.request.v2;
+
+
+import com.musinsam.orderservice.domain.order.entity.OrderEntity;
+import com.musinsam.orderservice.domain.order.entity.OrderItemEntity;
+import com.musinsam.orderservice.domain.order.vo.OrderStatus;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReqOrderPostDtoApiV2 {
+
+  @Valid
+  @NotNull(message = "주문 정보가 존재하지 않습니다.")
+  private ReqOrderPostDtoApiV2.Order order;
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Order {
+
+    private List<OrderItem> orderItems;
+    private ShippingInfo shippingInfo;
+    private String request;
+    private String orderName;
+    private UUID couponId;
+    private BigDecimal totalAmount;
+    private BigDecimal discountAmount;
+    private BigDecimal finalAmount;
+
+    public OrderEntity toEntityWith(Long userId) {
+      OrderEntity orderEntity = OrderEntity.builder()
+          .userId(userId)
+          .totalAmount(getTotalAmount())
+          .discountAmount(getDiscountAmount())
+          .finalAmount(getFinalAmount())
+          .totalQuantity(calculateTotalQuantity())
+          .request(getRequest())
+          .orderName(getOrderName())
+          .couponId(getCouponId())
+          .orderStatus(OrderStatus.PENDING)
+          .build();
+
+      List<OrderItemEntity> itemEntities = getOrderItems().stream()
+          .map(item -> OrderItemEntity.builder()
+              .productId(item.getId())
+              .productName(item.getProductName())
+              .price(item.getPrice())
+              .quantity(item.getQuantity())
+              .build()
+          )
+          .toList();
+
+      orderEntity.assignOrderItems(itemEntities);
+      return orderEntity;
+    }
+
+    private Integer calculateTotalQuantity() {
+      return getOrderItems().stream()
+          .mapToInt(OrderItem::getQuantity)
+          .sum();
+    }
+
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OrderItem {
+
+      private UUID id;
+      private String productName;
+      private BigDecimal price;
+
+      @NotNull(message = "상품 수량을 입력해주세요.")
+      private Integer quantity;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ShippingInfo {
+
+      private String receiverName;
+      private String receiverPhone;
+      private String zipCode;
+      private String address;
+      private String addressDetail;
+    }
+  }
+}

--- a/order-service/src/main/java/com/musinsam/orderservice/application/dto/response/v2/ResOrderPostCancelDtoApiV2.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/dto/response/v2/ResOrderPostCancelDtoApiV2.java
@@ -1,0 +1,47 @@
+package com.musinsam.orderservice.application.dto.response.v2;
+
+import com.musinsam.orderservice.domain.order.entity.OrderEntity;
+import com.musinsam.orderservice.domain.order.vo.OrderCancelType;
+import com.musinsam.orderservice.domain.order.vo.OrderStatus;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResOrderPostCancelDtoApiV2 {
+
+  private Order order;
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Order {
+
+    private UUID id;
+    private OrderStatus orderStatus;
+    private ZonedDateTime canceledAt;
+    private OrderCancelType orderCancelType;
+
+    public static Order from(OrderEntity entity) {
+      return Order.builder()
+          .id(entity.getId())
+          .orderStatus(entity.getOrderStatus())
+          .canceledAt(entity.getCanceledAt())
+          .orderCancelType(entity.getCancelType())
+          .build();
+    }
+  }
+
+  public static ResOrderPostCancelDtoApiV2 of(OrderEntity entity) {
+    return ResOrderPostCancelDtoApiV2.builder()
+        .order(Order.from(entity))
+        .build();
+  }
+}

--- a/order-service/src/main/java/com/musinsam/orderservice/application/dto/response/v2/ResOrderPostDtoApiV2.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/dto/response/v2/ResOrderPostDtoApiV2.java
@@ -1,0 +1,99 @@
+package com.musinsam.orderservice.application.dto.response.v2;
+
+import com.musinsam.orderservice.domain.order.entity.OrderEntity;
+import com.musinsam.orderservice.domain.order.entity.OrderItemEntity;
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResOrderPostDtoApiV2 {
+
+  private Order order;
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Order {
+
+    private UUID id;
+    private Long userId;
+    private String orderStatus;
+    private List<OrderItem> orderItems;
+    private BigDecimal totalAmount;
+    private BigDecimal discountAmount;
+    private BigDecimal finalAmount;
+    private String request;
+    private String orderName;
+    private ZonedDateTime createdAt;
+
+    public static Order from(OrderEntity orderEntity) {
+
+      List<Order.OrderItem> orderItems = orderEntity.getOrderItems().stream()
+          .map(OrderItem::from)
+          .toList();
+
+      return Order.builder()
+          .id(orderEntity.getId())
+          .userId(orderEntity.getUserId())
+          .orderItems(orderItems)
+          .orderStatus(orderEntity.getOrderStatus().name())
+          .totalAmount(orderEntity.getTotalAmount())
+          .discountAmount(orderEntity.getDiscountAmount())
+          .finalAmount(orderEntity.getFinalAmount())
+          .request(orderEntity.getRequest())
+          .orderName(orderEntity.getOrderName())
+          .createdAt(orderEntity.getCreatedAt())
+          .build();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OrderItem {
+
+      private UUID productId;
+      private String productName;
+      private Integer quantity;
+      private BigDecimal price;
+
+      public static OrderItem from(OrderItemEntity orderItemEntity) {
+        return OrderItem.builder()
+            .productId(orderItemEntity.getProductId())
+            .productName(orderItemEntity.getProductName())
+            .quantity(orderItemEntity.getQuantity())
+            .price(orderItemEntity.getPrice())
+            .build();
+      }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ShippingInfo {
+
+      private String receiverName;
+      private String receiverPhone;
+      private String zipCode;
+      private String address;
+      private String addressDetail;
+    }
+  }
+
+  public static ResOrderPostDtoApiV2 of(OrderEntity orderEntity) {
+    return ResOrderPostDtoApiV2.builder()
+        .order(Order.from(orderEntity))
+        .build();
+  }
+}

--- a/order-service/src/main/java/com/musinsam/orderservice/application/service/v2/OrderServiceApiV2.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/application/service/v2/OrderServiceApiV2.java
@@ -1,0 +1,78 @@
+package com.musinsam.orderservice.application.service.v2;
+
+import com.musinsam.orderservice.application.dto.request.v2.ReqOrderPostCancelDtoApiV2;
+import com.musinsam.orderservice.application.dto.request.v2.ReqOrderPostDtoApiV2;
+import com.musinsam.orderservice.application.dto.response.v2.ResOrderPostCancelDtoApiV2;
+import com.musinsam.orderservice.application.dto.response.v2.ResOrderPostDtoApiV2;
+import com.musinsam.orderservice.application.service.OrderStockManagerV1;
+import com.musinsam.orderservice.application.service.OrderValidatorV1;
+import com.musinsam.orderservice.domain.order.entity.OrderEntity;
+import com.musinsam.orderservice.domain.order.entity.OrderItemEntity;
+import com.musinsam.orderservice.domain.order.exception.OrderException;
+import com.musinsam.orderservice.domain.order.repository.OrderRepository;
+import com.musinsam.orderservice.domain.order.vo.OrderErrorCode;
+import com.musinsam.orderservice.infrastructure.config.OrderRedisLockTemplate;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderServiceApiV2 {
+
+  private final OrderRepository orderRepository;
+  private final OrderValidatorV1 orderValidator;
+  private final OrderStockManagerV1 orderStockManager;
+  private final OrderRedisLockTemplate orderRedisLockTemplate;
+
+  @Transactional
+  public ResOrderPostDtoApiV2 createOrder(ReqOrderPostDtoApiV2 requestDto, Long userId) {
+
+    OrderEntity orderEntity = requestDto.getOrder().toEntityWith(userId);
+
+    orderValidator.validateOrderOwner(orderEntity, userId);
+    orderValidator.validateOrderStatus(orderEntity);
+
+    List<UUID> orderItemIds = orderEntity.getOrderItems().stream()
+        .map(OrderItemEntity::getProductId)
+        .toList();
+
+    return orderRedisLockTemplate.executeWithLock(orderItemIds, () -> {
+      OrderEntity savedOrder = orderRepository.save(orderEntity);
+
+      boolean stockAvailable = orderStockManager.checkAndReduceStock(orderEntity);
+      if (!stockAvailable) {
+        throw OrderException.from(OrderErrorCode.ORDER_PRODUCT_NOT_AVAILABLE);
+      }
+
+      return ResOrderPostDtoApiV2.of(savedOrder);
+    });
+  }
+
+  @Transactional
+  public ResOrderPostCancelDtoApiV2 cancelOrder(UUID orderId, ReqOrderPostCancelDtoApiV2 requestDto,
+      Long userId) {
+    OrderEntity orderEntity = orderRepository.findByIdWithOrderItems(orderId)
+        .orElseThrow(() -> OrderException.from(OrderErrorCode.ORDER_NOT_FOUND));
+
+    orderValidator.validateOrderOwner(orderEntity, userId);
+    orderValidator.validateCancellableStatus(orderEntity);
+
+    List<UUID> productIds = orderEntity.getOrderItems().stream()
+        .map(OrderItemEntity::getProductId)
+        .toList();
+
+    return orderRedisLockTemplate.executeWithLock(productIds, () -> {
+      orderEntity.cancel(
+          requestDto.getOrder().getCancelType(),
+          requestDto.getOrder().getCancelReason()
+      );
+
+      orderStockManager.restoreProductStock(orderEntity);
+
+      return ResOrderPostCancelDtoApiV2.of(orderEntity);
+    });
+  }
+}

--- a/order-service/src/main/java/com/musinsam/orderservice/domain/order/vo/OrderErrorCode.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/domain/order/vo/OrderErrorCode.java
@@ -28,7 +28,8 @@ public enum OrderErrorCode implements ErrorCode {
   ORDER_CANNOT_BE_DELETED(-1, "Order cannot be deleted",
       HttpStatus.BAD_REQUEST),
   ORDER_STOCK_RESTORE_FAILED(-1, "Stock Restore request failed",
-      HttpStatus.BAD_REQUEST);
+      HttpStatus.BAD_REQUEST),
+  ORDER_LOCK_FAILED(-1, "Order lock failed", HttpStatus.INTERNAL_SERVER_ERROR);
 
   private final Integer code;
   private final String message;

--- a/order-service/src/main/java/com/musinsam/orderservice/infrastructure/client/ProductFeignClient.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/infrastructure/client/ProductFeignClient.java
@@ -9,7 +9,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(
     name = "product-service",
-    configuration = FeignConfig.class
+    configuration = FeignConfig.class,
+    url = "http://localhost:11002"
 )
 public interface ProductFeignClient {
 

--- a/order-service/src/main/java/com/musinsam/orderservice/infrastructure/config/OrderRedisLockTemplate.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/infrastructure/config/OrderRedisLockTemplate.java
@@ -1,0 +1,55 @@
+package com.musinsam.orderservice.infrastructure.config;
+
+import com.musinsam.orderservice.domain.order.exception.OrderException;
+import com.musinsam.orderservice.domain.order.vo.OrderErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderRedisLockTemplate {
+
+  private final RedissonClient redissonClient;
+
+  public <T> T executeWithLock(List<UUID> orderItemIds, Supplier<T> action) {
+    List<RLock> locks = new ArrayList<>();
+
+    try {
+      for (UUID orderItemId : orderItemIds) {
+        String lockKey = "product_lock:" + orderItemId;
+        RLock lock = redissonClient.getLock(lockKey);
+
+        boolean isLocked = lock.tryLock(5, 10, TimeUnit.SECONDS);
+        if (!isLocked) {
+          releaseAllLocks(locks);
+          throw OrderException.from(OrderErrorCode.ORDER_LOCK_FAILED);
+        }
+
+        locks.add(lock);
+      }
+
+      return action.get();
+
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw OrderException.from(OrderErrorCode.ORDER_LOCK_FAILED);
+    } finally {
+      releaseAllLocks(locks);
+    }
+  }
+
+  private void releaseAllLocks(List<RLock> locks) {
+    locks.forEach(lock -> {
+      if (lock.isHeldByCurrentThread()) {
+        lock.unlock();
+      }
+    });
+  }
+}

--- a/order-service/src/main/java/com/musinsam/orderservice/infrastructure/config/RedisConfig.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/infrastructure/config/RedisConfig.java
@@ -1,0 +1,26 @@
+package com.musinsam.orderservice.infrastructure.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String redisHost;
+
+  @Value("${spring.data.redis.port}")
+  private int redisPort;
+
+  @Bean
+  public RedissonClient redissonClient() {
+    Config config = new Config();
+    config.useSingleServer()
+        .setAddress("redis://" + redisHost + ":" + redisPort);
+    return Redisson.create(config);
+  }
+}

--- a/order-service/src/main/java/com/musinsam/orderservice/infrastructure/config/RedisConfig.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/infrastructure/config/RedisConfig.java
@@ -16,7 +16,7 @@ public class RedisConfig {
   @Value("${spring.data.redis.port}")
   private int redisPort;
 
-  @Bean
+  @Bean(destroyMethod = "shutdown")
   public RedissonClient redissonClient() {
     Config config = new Config();
     config.useSingleServer()

--- a/order-service/src/main/java/com/musinsam/orderservice/presentation/controller/v2/OrderControllerApiV2.java
+++ b/order-service/src/main/java/com/musinsam/orderservice/presentation/controller/v2/OrderControllerApiV2.java
@@ -1,0 +1,78 @@
+package com.musinsam.orderservice.presentation.controller.v2;
+
+import static com.musinsam.orderservice.domain.order.vo.OrderResponseCode.ORDER_CANCEL_SUCCESS;
+import static com.musinsam.orderservice.domain.order.vo.OrderResponseCode.ORDER_POST_SUCCESS;
+
+import com.musinsam.common.aop.CustomPreAuthorize;
+import com.musinsam.common.resolver.CurrentUser;
+import com.musinsam.common.response.ApiResponse;
+import com.musinsam.common.user.CurrentUserDtoApiV1;
+import com.musinsam.common.user.UserRoleType;
+import com.musinsam.orderservice.application.dto.request.v2.ReqOrderPostCancelDtoApiV2;
+import com.musinsam.orderservice.application.dto.request.v2.ReqOrderPostDtoApiV2;
+import com.musinsam.orderservice.application.dto.response.v2.ResOrderPostCancelDtoApiV2;
+import com.musinsam.orderservice.application.dto.response.v2.ResOrderPostDtoApiV2;
+import com.musinsam.orderservice.application.service.v2.OrderServiceApiV2;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/orders")
+public class OrderControllerApiV2 {
+
+  private final OrderServiceApiV2 orderServiceApiV2;
+
+  @PostMapping
+  @CustomPreAuthorize(userRoleType = {
+      UserRoleType.ROLE_MASTER,
+      UserRoleType.ROLE_COMPANY,
+      UserRoleType.ROLE_USER
+  })
+  public ResponseEntity<ApiResponse<ResOrderPostDtoApiV2>> createOrder(
+      @Valid @RequestBody ReqOrderPostDtoApiV2 requestDto,
+      @CurrentUser CurrentUserDtoApiV1 currentUser
+  ) {
+    ResOrderPostDtoApiV2 responseDto = orderServiceApiV2.createOrder(requestDto,
+        currentUser.userId());
+
+    return ResponseEntity.ok().body(
+        ApiResponse.success(
+            ORDER_POST_SUCCESS.getCode(),
+            ORDER_POST_SUCCESS.getMessage(),
+            responseDto
+        )
+    );
+  }
+
+  @PostMapping("/{orderId}/cancel")
+  @CustomPreAuthorize(userRoleType = {
+      UserRoleType.ROLE_MASTER,
+      UserRoleType.ROLE_COMPANY,
+      UserRoleType.ROLE_USER
+  })
+  public ResponseEntity<ApiResponse<ResOrderPostCancelDtoApiV2>> cancelOrder(
+      @PathVariable UUID orderId,
+      @Valid @RequestBody ReqOrderPostCancelDtoApiV2 requestDto,
+      @CurrentUser CurrentUserDtoApiV1 currentUser
+  ) {
+
+    ResOrderPostCancelDtoApiV2 responseDto = orderServiceApiV2.cancelOrder(orderId, requestDto,
+        currentUser.userId());
+
+    return ResponseEntity.ok().body(
+        ApiResponse.success(
+            ORDER_CANCEL_SUCCESS.getCode(),
+            ORDER_CANCEL_SUCCESS.getMessage(),
+            responseDto
+        )
+    );
+  }
+}

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -26,6 +26,13 @@ spring:
     open-in-view: false
     defer-datasource-initialization: true
 
+  data:
+    redis:
+      host: localhost
+      port: 6381
+      username: default
+      password: systempass
+
 eureka:
   client:
     register-with-eureka: true

--- a/order-service/src/test/java/com/musinsam/orderservice/application/service/OrderConcurrencyTest.java
+++ b/order-service/src/test/java/com/musinsam/orderservice/application/service/OrderConcurrencyTest.java
@@ -1,0 +1,263 @@
+package com.musinsam.orderservice.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+
+import com.musinsam.orderservice.application.dto.request.ReqOrderPostDtoApiV1;
+import com.musinsam.orderservice.application.dto.request.v2.ReqOrderPostDtoApiV2;
+import com.musinsam.orderservice.application.service.v2.OrderServiceApiV2;
+import com.musinsam.orderservice.infrastructure.client.ProductFeignClient;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class OrderConcurrencyTest {
+
+  @Autowired
+  private OrderServiceApiV1 orderServiceApiV1;
+
+  @Autowired
+  private OrderServiceApiV2 orderServiceApiV2;
+
+  @MockitoBean
+  private ProductFeignClient productFeignClient;
+
+  private UUID productId;
+  private final int INITIAL_STOCK = 100;
+  private final AtomicInteger stockCount = new AtomicInteger(INITIAL_STOCK);
+  private final AtomicInteger decrementCounter = new AtomicInteger(0);
+  private final AtomicInteger raceConditionCounter = new AtomicInteger(0);
+
+  @BeforeEach
+  void setUp() {
+    productId = UUID.randomUUID();
+    stockCount.set(INITIAL_STOCK);
+    decrementCounter.set(0);
+    raceConditionCounter.set(0);
+
+    doAnswer(invocation -> {
+      UUID pid = invocation.getArgument(0);
+      int quantity = invocation.getArgument(1);
+
+      int currentStock = stockCount.get();
+
+      // 동시성 문제 감지 및 카운팅
+      int threadsReadingSameStock = detectConcurrentReads(currentStock);
+      if (threadsReadingSameStock > 1) {
+        raceConditionCounter.incrementAndGet();
+      }
+
+      // race condition 발생을 위한 의도적인 지연
+      Thread.sleep(5);
+
+      if (currentStock >= quantity) {
+        stockCount.set(currentStock - quantity);
+        decrementCounter.incrementAndGet();
+        return ResponseEntity.ok(true);
+      } else {
+        return ResponseEntity.ok(false);
+      }
+    }).when(productFeignClient).checkAndReduceStock(any(UUID.class), anyInt());
+
+    doAnswer(invocation -> {
+      UUID pid = invocation.getArgument(0);
+      int quantity = invocation.getArgument(1);
+
+      stockCount.updateAndGet(current -> current + quantity);
+      return ResponseEntity.ok().build();
+    }).when(productFeignClient).restoreStock(any(UUID.class), anyInt());
+  }
+
+  private int detectConcurrentReads(int stockValue) {
+    return (int) (Math.random() * 3) + 1; // test 용이므로 임의의 값 반환
+  }
+
+  @Test
+  @DisplayName("OrderServiceV2 (분산락 적용) - 100개의 동시 주문 테스트")
+  void orderServiceV2Concurrent100UsersTest() throws InterruptedException {
+    stockCount.set(INITIAL_STOCK);
+    decrementCounter.set(0);
+    raceConditionCounter.set(0);
+
+    int numberOfThreads = 100;
+    ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+    CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+    List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
+    AtomicInteger successCount = new AtomicInteger(0);
+
+    for (int i = 0; i < numberOfThreads; i++) {
+      executorService.submit(() -> {
+        try {
+          ReqOrderPostDtoApiV2 requestDto = createOrderRequest(productId, 1);
+          orderServiceApiV2.createOrder(requestDto, 1L);
+          successCount.incrementAndGet();
+        } catch (Exception e) {
+          exceptions.add(e);
+        } finally {
+          latch.countDown();
+        }
+      });
+    }
+
+    latch.await();
+    executorService.shutdown();
+
+    // 결과 출력 및 검증
+    System.out.println("=== OrderServiceV2 분산락 적용 결과 ===");
+    System.out.println("초기 재고: " + INITIAL_STOCK);
+    System.out.println("요청 주문 수: " + numberOfThreads);
+    System.out.println("성공한 주문 수: " + successCount.get());
+    System.out.println("실패한 주문 수: " + exceptions.size());
+    System.out.println("예상 잔여 재고: " + (INITIAL_STOCK - numberOfThreads));
+    System.out.println("실제 잔여 재고: " + stockCount.get());
+
+    System.out.println("재고 차감 시도 횟수: " + decrementCounter.get());
+    System.out.println("감지된 Race Condition 발생: " + raceConditionCounter.get());
+
+    // 분산락 적용 시 재고가 정확히 차감되어야 함
+    assertThat(stockCount.get()).isEqualTo(INITIAL_STOCK - successCount.get());
+    assertThat(successCount.get()).isEqualTo(numberOfThreads);
+    assertThat(decrementCounter.get()).isEqualTo(numberOfThreads);
+  }
+
+  @Test
+  @DisplayName("OrderServiceV1 (분산락 미적용) - 100개의 동시 주문 테스트")
+  void orderServiceV1Concurrent100UsersTest() throws InterruptedException {
+    // 테스트 전 재고 초기화
+    stockCount.set(INITIAL_STOCK);
+    decrementCounter.set(0);
+    raceConditionCounter.set(0);
+
+    int numberOfThreads = 100;
+    ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+    CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+    List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
+    AtomicInteger successCount = new AtomicInteger(0);
+
+    for (int i = 0; i < numberOfThreads; i++) {
+      executorService.submit(() -> {
+        try {
+          ReqOrderPostDtoApiV1 requestDto = createOrderRequestV1(productId, 1);
+          orderServiceApiV1.createOrder(requestDto, 1L);
+          successCount.incrementAndGet();
+        } catch (Exception e) {
+          exceptions.add(e);
+        } finally {
+          latch.countDown();
+        }
+      });
+    }
+
+    latch.await();
+    executorService.shutdown();
+
+    // 결과 출력 및 검증
+    System.out.println("=== OrderServiceV1 분산락 미적용 ===");
+    System.out.println("초기 재고: " + INITIAL_STOCK);
+    System.out.println("요청 주문 수: " + numberOfThreads);
+    System.out.println("성공한 주문 수: " + successCount.get());
+    System.out.println("실패한 주문 수: " + exceptions.size());
+    System.out.println("예상 잔여 재고: " + (INITIAL_STOCK - numberOfThreads));
+    System.out.println("실제 잔여 재고: " + stockCount.get());
+
+    System.out.println("재고 차감 시도 횟수: " + decrementCounter.get());
+    System.out.println("감지된 Race Condition 발생: " + raceConditionCounter.get());
+
+    // 모든 주문이 성공했으나, 실제 재고는 정확하지 차감되지 않았을 것
+    assertThat(successCount.get()).isEqualTo(numberOfThreads);
+    assertThat(stockCount.get()).isGreaterThan(0);
+    assertNotEquals(INITIAL_STOCK - successCount.get(), stockCount.get(),
+        "분산락 없이 정확한 재고 차감은 불가능해야 함");
+  }
+
+  /**
+   * 테스트용 주문 요청 임의의 객체 생성 메서드
+   */
+  private ReqOrderPostDtoApiV1 createOrderRequestV1(UUID productId, int quantity) {
+    ReqOrderPostDtoApiV1.Order.OrderItem orderItem = ReqOrderPostDtoApiV1.Order.OrderItem.builder()
+        .id(productId)
+        .productName("Test Product")
+        .price(BigDecimal.valueOf(10000))
+        .quantity(quantity)
+        .build();
+
+    ReqOrderPostDtoApiV1.Order.ShippingInfo shippingInfo = ReqOrderPostDtoApiV1.Order.ShippingInfo.builder()
+        .receiverName("Jone Doe")
+        .receiverPhone("010-1234-5678")
+        .zipCode("12345")
+        .address("서울특별시 테스트구")
+        .addressDetail("테스트동 101호")
+        .build();
+
+    ReqOrderPostDtoApiV1.Order order = ReqOrderPostDtoApiV1.Order.builder()
+        .orderItems(List.of(orderItem))
+        .shippingInfo(shippingInfo)
+        .request("테스트 요청사항")
+        .orderName("테스트 주문")
+        .totalAmount(orderItem.getPrice().multiply(BigDecimal.valueOf(orderItem.getQuantity())))
+        .discountAmount(BigDecimal.ZERO)
+        .finalAmount(orderItem.getPrice().multiply(BigDecimal.valueOf(orderItem.getQuantity()))
+            .subtract(BigDecimal.ZERO))
+        .build();
+
+    return ReqOrderPostDtoApiV1.builder()
+        .order(order)
+        .build();
+  }
+
+  /**
+   * 테스트용 주문 요청 임의의 객체 생성 메서드
+   */
+  private ReqOrderPostDtoApiV2 createOrderRequest(UUID productId, int quantity) {
+    ReqOrderPostDtoApiV2.Order.OrderItem orderItem = ReqOrderPostDtoApiV2.Order.OrderItem.builder()
+        .id(productId)
+        .productName("Test Product")
+        .price(BigDecimal.valueOf(10000))
+        .quantity(quantity)
+        .build();
+
+    ReqOrderPostDtoApiV2.Order.ShippingInfo shippingInfo = ReqOrderPostDtoApiV2.Order.ShippingInfo.builder()
+        .receiverName("Jone Doe")
+        .receiverPhone("010-1234-5678")
+        .zipCode("12345")
+        .address("서울특별시 테스트구")
+        .addressDetail("테스트동 101호")
+        .build();
+
+    ReqOrderPostDtoApiV2.Order order = ReqOrderPostDtoApiV2.Order.builder()
+        .orderItems(List.of(orderItem))
+        .shippingInfo(shippingInfo)
+        .request("테스트 요청사항")
+        .orderName("테스트 주문")
+        .totalAmount(orderItem.getPrice().multiply(BigDecimal.valueOf(orderItem.getQuantity())))
+        .discountAmount(BigDecimal.ZERO)
+        .finalAmount(orderItem.getPrice().multiply(BigDecimal.valueOf(orderItem.getQuantity()))
+            .subtract(BigDecimal.ZERO))
+        .build();
+
+    return ReqOrderPostDtoApiV2.builder()
+        .order(order)
+        .build();
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #228 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 주문 서비스 API v2가 추가되어 주문 생성 및 취소 기능을 제공합니다.
    - 주문 생성/취소 요청 및 응답을 위한 새로운 DTO가 도입되었습니다.
    - 주문 생성 및 취소 시 분산 락(Distributed Lock) 기반의 재고 보호 기능이 적용되었습니다.
    - 주문 서비스에 Redis 및 Redisson 연동이 추가되었습니다.
    - 주문 관련 부하 테스트 및 분산 락 테스트를 위한 k6 스크립트와 Docker 서비스가 추가되었습니다.
    - 주문 API v2 전용 컨트롤러가 추가되어 권한 기반 접근 제어를 지원합니다.

- **Bug Fixes**
    - 게이트웨이에서 주문 서비스로의 라우팅 경로가 `/v2/orders/**`까지 확장되었습니다.

- **Chores**
    - 주문 서비스의 Redis 및 Redisson 의존성이 추가되었습니다.
    - 주문 서비스와 인프라 환경설정에 Redis 및 관련 설정이 반영되었습니다.
    - Feign 클라이언트에 주문 서비스 호출용 URL이 명시적으로 지정되었습니다.
    - README 파일 내용이 이미지 링크로 교체되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->